### PR TITLE
add ability to extend configuration.py

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -65,6 +65,11 @@ data:
                                      in REDIS['caching']['SENTINELS']]
     {{- end }}
 
+    # Extra Configuration
+    {{- range .Values.customPythonConfig }}
+    {{ . }}
+    {{- end }}
+
   netbox.yaml: |
     ALLOWED_HOSTS: {{ toJson .Values.allowedHosts }}
 

--- a/values.yaml
+++ b/values.yaml
@@ -284,6 +284,12 @@ remoteAuth:
   staffUsers: []
   groupSeparator: '|'
 
+# Extend configuration.py
+customPythonConfig: []
+  # - "SOCIAL_AUTH_OKTA_OPENIDCONNECT_KEY = '<key>'"
+  # - "SOCIAL_AUTH_OKTA_OPENIDCONNECT_SECRET = '<secret>'"
+
+
   # The following options are specific for backend "netbox.authentication.LDAPBackend"
   # you can use an existing netbox secret with "ldap_bind_password" instead of "bindPassword"
   # see https://django-auth-ldap.readthedocs.io


### PR DESCRIPTION
This gives the ability to extend the configuration.py file populated by the configMap.

Use case: adding an Okta OIDC integration using the social-auth library.

current workaround: editing the configmap manually after helm install and then redeploying the deployment