### PR TITLE
add ability to inject secrets in the pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,8 @@ The following table lists the configurable parameters for this chart and their d
 | `extraInitContainers`                           | Additional init containers to run before starting main containers   | `[]`                                         |
 | `worker`                                        | Worker specific variables. Most global variables also apply here.   | *see `values.yaml`*                          |
 | `housekeeping.enabled`                          | Whether the [Housekeeping][housekeeping] `CronJob` should be active | `true`                                       |
+| `housekeeping.args`.                            | Custom start up arguments for netbox container arguments.           | `[]`                                         |
+| `housekeeping.command`                          | Custom container entrypoint.                                        | ["/opt/netbox/venv/bin/python","/opt/netbox/netbox/manage.py",rqworker] |
 | `housekeeping.concurrencyPolicy`                | ConcurrencyPolicy for the Housekeeping CronJob.                     | `Forbid`                                     |
 | `housekeeping.failedJobsHistoryLimit`           | Number of failed jobs to keep in history                            | `5`                                          |
 | `housekeeping.restartPolicy`                    | Restart Policy for the Housekeeping CronJob.                        | `OnFailure`                                  |

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -65,6 +65,8 @@ data:
                                      in REDIS['caching']['SENTINELS']]
     {{- end }}
 
+    _load_yaml()
+
   netbox.yaml: |
     ALLOWED_HOSTS: {{ toJson .Values.allowedHosts }}
 

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -55,9 +55,9 @@ spec:
                 {{- toYaml .Values.housekeeping.securityContext | nindent 16 }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               command:
-                - /opt/netbox/venv/bin/python
-                - /opt/netbox/netbox/manage.py
-                - housekeeping
+              {{- toYaml .Values.housekeeping.command | nindent 16 }}
+              args:
+              {{- toYaml .Values.housekeeping.args | nindent 16 }}
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               {{- with .Values.housekeeping.extraEnvs }}
               env:

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -57,9 +57,9 @@ spec:
             {{- toYaml .Values.worker.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command:
-            - /opt/netbox/venv/bin/python
-            - /opt/netbox/netbox/manage.py
-            - rqworker
+          {{- toYaml .Values.worker.command | nindent 12 }}
+          args:
+          {{- toYaml .Values.worker.args | nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.worker.extraEnvs }}
           env:

--- a/values.yaml
+++ b/values.yaml
@@ -695,6 +695,12 @@ serviceMonitor:
 # Configuration of Cron settings
 housekeeping:
   enabled: true
+
+  args: []
+  command:
+    - /opt/netbox/venv/bin/python
+    - /opt/netbox/netbox/manage.py
+    - housekeeping
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 5
   restartPolicy: OnFailure
@@ -773,6 +779,12 @@ housekeeping:
 # Only required for Netbox Jobs, e.g. Webhooks
 worker:
   enabled: true
+
+  args: []
+  command:
+    - /opt/netbox/venv/bin/python
+    - /opt/netbox/netbox/manage.py
+    - rqworker
 
   replicaCount: 1
 


### PR DESCRIPTION
This issues is attempt to enable injecting of secrets via vault or other such tools. The issue is described here: https://github.com/bootc/netbox-chart/issues/160.
With this change we can 
- call `consul-template -exec "/opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py rqworker` at the entrypoint so vault can managed injection of the extra secrets.
- vault will read the secrets from vault store and mount them in yaml format at `/run/config/extra/vault/secrets.yaml`
- configuration.py will read secrets from `/run/config/extra/vault/secrets.yaml` and override the previously read the secets

Let me know if this makes sense.

Closes #160 