### PR TITLE
Add optional loadBalancerClass in service spec

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -46,6 +46,9 @@ spec:
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}
   {{- end }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass | quote }}
+  {{- end }}
   {{- with .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
   {{- toYaml . | nindent 2 }}


### PR DESCRIPTION
To use another load balancer class, we need the ability to specify LoadBalancerClass for services