### PR TITLE
Changed Templates to use the new remoteAuth.backends array, instead of .backend

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta7
+version: 5.0.0-beta8
 appVersion: "v4.0.0"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -224,7 +224,8 @@ data:
     DATETIME_FORMAT: {{ .Values.dateTimeFormat | quote }}
     SHORT_DATETIME_FORMAT: {{ .Values.shortDateTimeFormat | quote }}
 
-  {{- if eq .Values.remoteAuth.backend "netbox.authentication.LDAPBackend" }}
+  {{- range .Values.remoteAuth.backends }}
+  {{- if eq . "netbox.authentication.LDAPBackend" }}
 
   ldap_config.py: |-
     from importlib import import_module
@@ -276,32 +277,33 @@ data:
     # Define special user types using groups. Exercise great caution when assigning superuser status.
     AUTH_LDAP_USER_FLAGS_BY_GROUP = {
         "is_active": AUTH_LDAP_REQUIRE_GROUP,
-        "is_staff": {{ .Values.remoteAuth.ldap.isAdminDn | quote }},
-        "is_superuser": {{ .Values.remoteAuth.ldap.isSuperUserDn | quote }},
+        "is_staff": {{ $.Values.remoteAuth.ldap.isAdminDn | quote }},
+        "is_superuser": {{ $.Values.remoteAuth.ldap.isSuperUserDn | quote }},
     }
     # Populate the Django user from the LDAP directory.
     AUTH_LDAP_USER_ATTR_MAP = {
-        "first_name": {{ .Values.remoteAuth.ldap.attrFirstName | quote }},
-        "last_name": {{ .Values.remoteAuth.ldap.attrLastName | quote }},
-        "email": {{ .Values.remoteAuth.ldap.attrMail | quote }},
+        "first_name": {{ $.Values.remoteAuth.ldap.attrFirstName | quote }},
+        "last_name": {{ $.Values.remoteAuth.ldap.attrLastName | quote }},
+        "email": {{ $.Values.remoteAuth.ldap.attrMail | quote }},
     }
 
   ldap.yaml: |-
-    AUTH_LDAP_SERVER_URI: {{ .Values.remoteAuth.ldap.serverUri | quote }}
-    AUTH_LDAP_BIND_DN: {{ .Values.remoteAuth.ldap.bindDn | quote }}
-    AUTH_LDAP_START_TLS: {{ toJson .Values.remoteAuth.ldap.startTls }}
-    LDAP_IGNORE_CERT_ERRORS: {{ toJson .Values.remoteAuth.ldap.ignoreCertErrors }}
-    AUTH_LDAP_USER_DN_TEMPLATE: {{ default nil .Values.remoteAuth.ldap.userDnTemplate }}
-    AUTH_LDAP_USER_SEARCH_BASEDN: {{ .Values.remoteAuth.ldap.userSearchBaseDn | quote }}
-    AUTH_LDAP_USER_SEARCH_ATTR: {{ .Values.remoteAuth.ldap.userSearchAttr | quote }}
-    AUTH_LDAP_GROUP_SEARCH_BASEDN: {{ .Values.remoteAuth.ldap.groupSearchBaseDn | quote }}
-    AUTH_LDAP_GROUP_SEARCH_CLASS: {{ .Values.remoteAuth.ldap.groupSearchClass | quote }}
-    AUTH_LDAP_GROUP_TYPE: {{ .Values.remoteAuth.ldap.groupType | quote }}
-    AUTH_LDAP_REQUIRE_GROUP: {{ .Values.remoteAuth.ldap.requireGroupDn | quote }}
-    AUTH_LDAP_FIND_GROUP_PERMS: {{ toJson .Values.remoteAuth.ldap.findGroupPerms }}
-    AUTH_LDAP_MIRROR_GROUPS: {{ toJson .Values.remoteAuth.ldap.mirrorGroups }}
-    AUTH_LDAP_MIRROR_GROUPS_EXCEPT: {{ toJson .Values.remoteAuth.ldap.mirrorGroupsExcept }}
-    AUTH_LDAP_CACHE_TIMEOUT: {{ int .Values.remoteAuth.ldap.cacheTimeout }}
+    AUTH_LDAP_SERVER_URI: {{ $.Values.remoteAuth.ldap.serverUri | quote }}
+    AUTH_LDAP_BIND_DN: {{ $.Values.remoteAuth.ldap.bindDn | quote }}
+    AUTH_LDAP_START_TLS: {{ toJson $.Values.remoteAuth.ldap.startTls }}
+    LDAP_IGNORE_CERT_ERRORS: {{ toJson $.Values.remoteAuth.ldap.ignoreCertErrors }}
+    AUTH_LDAP_USER_DN_TEMPLATE: {{ default nil $.Values.remoteAuth.ldap.userDnTemplate }}
+    AUTH_LDAP_USER_SEARCH_BASEDN: {{ $.Values.remoteAuth.ldap.userSearchBaseDn | quote }}
+    AUTH_LDAP_USER_SEARCH_ATTR: {{ $.Values.remoteAuth.ldap.userSearchAttr | quote }}
+    AUTH_LDAP_GROUP_SEARCH_BASEDN: {{ $.Values.remoteAuth.ldap.groupSearchBaseDn | quote }}
+    AUTH_LDAP_GROUP_SEARCH_CLASS: {{ $.Values.remoteAuth.ldap.groupSearchClass | quote }}
+    AUTH_LDAP_GROUP_TYPE: {{ $.Values.remoteAuth.ldap.groupType | quote }}
+    AUTH_LDAP_REQUIRE_GROUP: {{ $.Values.remoteAuth.ldap.requireGroupDn | quote }}
+    AUTH_LDAP_FIND_GROUP_PERMS: {{ toJson $.Values.remoteAuth.ldap.findGroupPerms }}
+    AUTH_LDAP_MIRROR_GROUPS: {{ toJson $.Values.remoteAuth.ldap.mirrorGroups }}
+    AUTH_LDAP_MIRROR_GROUPS_EXCEPT: {{ toJson $.Values.remoteAuth.ldap.mirrorGroupsExcept }}
+    AUTH_LDAP_CACHE_TIMEOUT: {{ int $.Values.remoteAuth.ldap.cacheTimeout }}
+  {{- end }}
   {{- end }}
   {{- if .Values.overrideUnitConfig }}
 

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -61,11 +61,13 @@ spec:
               mountPath: /etc/netbox/config/configuration.py
               subPath: configuration.py
               readOnly: true
-            {{ if eq .Values.remoteAuth.backend "netbox.authentication.LDAPBackend" -}}
+            {{- range .Values.remoteAuth.backends }}
+            {{- if eq . "netbox.authentication.LDAPBackend" }}
             - name: config
               mountPath: /etc/netbox/config/ldap/ldap_config.py
               subPath: ldap_config.py
               readOnly: true
+            {{ end -}}
             {{ end -}}
             - name: config
               mountPath: /run/config/netbox
@@ -110,9 +112,11 @@ spec:
                     path: email_password
                   - key: secret_key
                     path: secret_key
-                  {{- if eq .Values.remoteAuth.backend "netbox.authentication.LDAPBackend" }}
+                  {{- range .Values.remoteAuth.backends }}
+                  {{- if eq . "netbox.authentication.LDAPBackend" }}
                   - key: ldap_bind_password
                     path: ldap_bind_password
+                  {{- end }}
                   {{- end }}
               - secret:
                   name: {{ include "netbox.postgresql.secret" . | quote }}

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -67,8 +67,8 @@ spec:
               mountPath: /etc/netbox/config/ldap/ldap_config.py
               subPath: ldap_config.py
               readOnly: true
-            {{ end -}}
-            {{ end -}}
+            {{- end }}
+            {{- end }}
             - name: config
               mountPath: /run/config/netbox
               readOnly: true

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -116,11 +116,13 @@ spec:
           mountPath: /etc/netbox/config/configuration.py
           subPath: configuration.py
           readOnly: true
-        {{ if eq .Values.remoteAuth.backend "netbox.authentication.LDAPBackend" -}}
+        {{- range .Values.remoteAuth.backends }}
+        {{- if eq . "netbox.authentication.LDAPBackend" }}
         - name: config
           mountPath: /etc/netbox/config/ldap/ldap_config.py
           subPath: ldap_config.py
           readOnly: true
+        {{ end -}}
         {{ end -}}
         - name: config
           mountPath: /run/config/netbox
@@ -180,9 +182,11 @@ spec:
                 path: email_password
               - key: secret_key
                 path: secret_key
-              {{- if eq .Values.remoteAuth.backend "netbox.authentication.LDAPBackend" }}
+              {{- range .Values.remoteAuth.backends }}
+              {{- if eq . "netbox.authentication.LDAPBackend" }}
               - key: ldap_bind_password
                 path: ldap_bind_password
+              {{- end }}
               {{- end }}
           - secret:
               name: {{ include "netbox.postgresql.secret" . | quote }}

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -122,8 +122,8 @@ spec:
           mountPath: /etc/netbox/config/ldap/ldap_config.py
           subPath: ldap_config.py
           readOnly: true
-        {{ end -}}
-        {{ end -}}
+        {{- end }}
+        {{- end }}
         - name: config
           mountPath: /run/config/netbox
           readOnly: true

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -23,7 +23,9 @@ data:
   secret_key: {{ .Values.secretKey | default (randAscii 60) | b64enc }}
   superuser_password: {{ .Values.superuser.password | default (randAlphaNum 16) | b64enc }}
   superuser_api_token: {{ .Values.superuser.apiToken | default uuidv4 | b64enc }}
-  {{ if eq .Values.remoteAuth.backend "netbox.authentication.LDAPBackend" -}}
-  ldap_bind_password: {{ .Values.remoteAuth.ldap.bindPassword | b64enc | quote }}
+  {{- range .Values.remoteAuth.backends }}
+  {{- if eq . "netbox.authentication.LDAPBackend" }}
+  ldap_bind_password: {{ $.Values.remoteAuth.ldap.bindPassword | b64enc | quote }}
   {{ end -}}
+  {{ end -}}  
 {{- end -}}

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -27,5 +27,5 @@ data:
   {{- if eq . "netbox.authentication.LDAPBackend" }}
   ldap_bind_password: {{ $.Values.remoteAuth.ldap.bindPassword | b64enc | quote }}
   {{ end -}}
-  {{ end -}}  
+  {{ end -}}
 {{- end -}}

--- a/charts/netbox/templates/worker-deployment.yaml
+++ b/charts/netbox/templates/worker-deployment.yaml
@@ -75,8 +75,8 @@ spec:
           mountPath: /etc/netbox/config/ldap/ldap_config.py
           subPath: ldap_config.py
           readOnly: true
-        {{ end -}}
-        {{ end -}}
+        {{- end }}
+        {{- end }}
         - name: config
           mountPath: /run/config/netbox
           readOnly: true

--- a/charts/netbox/templates/worker-deployment.yaml
+++ b/charts/netbox/templates/worker-deployment.yaml
@@ -69,11 +69,13 @@ spec:
           mountPath: /etc/netbox/config/configuration.py
           subPath: configuration.py
           readOnly: true
-        {{ if eq .Values.remoteAuth.backend "netbox.authentication.LDAPBackend" -}}
+        {{- range .Values.remoteAuth.backends }}
+        {{- if eq . "netbox.authentication.LDAPBackend" }}
         - name: config
           mountPath: /etc/netbox/config/ldap/ldap_config.py
           subPath: ldap_config.py
           readOnly: true
+        {{ end -}}
         {{ end -}}
         - name: config
           mountPath: /run/config/netbox
@@ -118,9 +120,11 @@ spec:
                 path: email_password
               - key: secret_key
                 path: secret_key
-              {{- if eq .Values.remoteAuth.backend "netbox.authentication.LDAPBackend" }}
+              {{- range .Values.remoteAuth.backends }}
+              {{- if eq . "netbox.authentication.LDAPBackend" }}
               - key: ldap_bind_password
                 path: ldap_bind_password
+              {{- end }}
               {{- end }}
           - secret:
               name: {{ include "netbox.postgresql.secret" . | quote }}


### PR DESCRIPTION
First helm related commit, so be gentle. :p 

In the new 5.0 release, remoteAuth.backend is deprecated and you have to specify both remoteAuth.backend and remoteAuth.backends to get a working LDAP configuration. 

This PR aims to fix that by removing all references to remoteAuth.backend.