### PR TITLE
add: optional overrides for command/args of Netbox container

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ The following table lists the configurable parameters for this chart and their d
 | `image.repository`                              | NetBox container image repository                                   | `netboxcommunity/netbox`                     |
 | `image.tag`                                     | NetBox container image tag                                          | `""`                                         |
 | `image.pullPolicy`                              | NetBox container image pull policy                                  | `IfNotPresent`                               |
+| `image.command`                                 | NetBox container image command/entrypoint                           | *unset, see Dockerfile*                      |
+| `image.args`                                    | NetBox container image args                                         | *unset, see Dockerfile*                      |
 | `superuser.name`                                | Initial super-user account to create                                | `admin`                                      |
 | `superuser.email`                               | Email address for the initial super-user account                    | `admin@example.com`                          |
 | `superuser.password`                            | Password for the initial super-user account                         | `admin`                                      |

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ The following table lists the configurable parameters for this chart and their d
 | `image.repository`                              | NetBox container image repository                                   | `netboxcommunity/netbox`                     |
 | `image.tag`                                     | NetBox container image tag                                          | `""`                                         |
 | `image.pullPolicy`                              | NetBox container image pull policy                                  | `IfNotPresent`                               |
-| `image.command`                                 | NetBox container image command/entrypoint                           | *unset, see Dockerfile*                      |
-| `image.args`                                    | NetBox container image args                                         | *unset, see Dockerfile*                      |
+| `image.command`                                 | NetBox container image command/entrypoint                           | `[]`                                         |
+| `image.args`                                    | NetBox container image args                                         | `[]`                                         |
 | `superuser.name`                                | Initial super-user account to create                                | `admin`                                      |
 | `superuser.email`                               | Email address for the initial super-user account                    | `admin@example.com`                          |
 | `superuser.password`                            | Password for the initial super-user account                         | `admin`                                      |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -69,6 +69,16 @@ spec:
           {{- toYaml .Values.securityContext | nindent 10 }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.image.command }}
+        command: {{ range . }}
+          - {{ . | quote }}
+        {{- end }}
+        {{- end }}
+        {{- with .Values.image.args }}
+        args: {{ range . }}
+          - {{ . | quote }}
+        {{- end }}
+        {{- end }}
         env:
         - name: SUPERUSER_NAME
           value: {{ .Values.superuser.name | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -9,6 +9,10 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  # Overrides the command used to run the container when set
+  command: []
+  # Overrides the args used to run the container when set
+  args: []
 
 # You can also use an existing secret for the superuser password and API token
 # See `existingSecret` for details

--- a/values.yaml
+++ b/values.yaml
@@ -10,9 +10,9 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   # Overrides the command used to run the container when set
-  command: []
+  # command: []
   # Overrides the args used to run the container when set
-  args: []
+  # args: []
 
 # You can also use an existing secret for the superuser password and API token
 # See `existingSecret` for details

--- a/values.yaml
+++ b/values.yaml
@@ -10,9 +10,9 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   # Overrides the command used to run the container when set
-  # command: []
+  command: []
   # Overrides the args used to run the container when set
-  # args: []
+  args: []
 
 # You can also use an existing secret for the superuser password and API token
 # See `existingSecret` for details


### PR DESCRIPTION
quick change to enable the override of the image's entrypoint. Enables some run-time modification of the default image without having to create a fork of it. 