### PR TITLE
Leverage Bitnami `common` chart helpers

### DIFF
--- a/charts/netbox/Chart.lock
+++ b/charts/netbox/Chart.lock
@@ -1,9 +1,12 @@
 dependencies:
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.19.2
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 13.4.6
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.19.4
-digest: sha256:280946da795a32a9f778256ffb43dd003da178c38930fb1deef9739c480ac183
-generated: "2024-04-17T19:56:33.810020245Z"
+digest: sha256:aca8217d7972de1fa6676ab69d10ef43ba8ec7f2f409cce620a960358d8f4b7d
+generated: "2024-05-02T15:26:40.653130602Z"

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0
+version: 5.0.0-beta0
 appVersion: "v3.6.4"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -29,3 +29,8 @@ dependencies:
     version: ^18.19.4
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Upstream Project
+      url: https://github.com/netbox-community/netbox

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -16,16 +16,16 @@ maintainers:
   - name: Chris Boot
     url: https://github.com/bootc
 dependencies:
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: ^2.19.1
+    tags:
+      - bitnami-common
   - name: postgresql
-    version: 13.x.x
+    version: ^13.4.6
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: redis
-    version: 18.x.x
+    version: ^18.19.4
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled
-annotations:
-  artifacthub.io/license: Apache-2.0
-  artifacthub.io/links: |
-    - name: Upstream Project
-      url: https://github.com/netbox-community/netbox

--- a/charts/netbox/templates/NOTES.txt
+++ b/charts/netbox/templates/NOTES.txt
@@ -8,21 +8,21 @@ NetBox should be available at the following URL(s) shortly:
 {{- else if contains "NodePort" .Values.service.type }}
 Get the application URL by running these commands:
 
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "netbox.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
 Get the application URL by running these commands:
 
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "netbox.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "netbox.fullname" . }}'
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "common.names.fullname" . }}'
 {{- else if contains "ClusterIP" .Values.service.type }}
 Get the application URL by running these commands:
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "netbox.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "common.names.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:8080
 {{- end }}

--- a/charts/netbox/templates/_helpers.tpl
+++ b/charts/netbox/templates/_helpers.tpl
@@ -1,63 +1,11 @@
 {{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "netbox.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "netbox.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "netbox.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Common labels
-*/}}
-{{- define "netbox.labels" -}}
-helm.sh/chart: {{ include "netbox.chart" . }}
-{{ include "netbox.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- with .Values.commonLabels }}
-{{ toYaml . }}
-{{- end }}
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "netbox.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "netbox.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
 {{- define "netbox.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "netbox.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "common.names.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
@@ -72,7 +20,7 @@ Name of the Secret that contains the PostgreSQL password
   {{- else if .Values.externalDatabase.existingSecretName }}
     {{- .Values.externalDatabase.existingSecretName }}
   {{- else }}
-    {{- .Values.existingSecret | default (include "netbox.fullname" .) }}
+    {{- .Values.existingSecret | default (include "common.names.fullname" .) }}
   {{- end }}
 {{- end }}
 
@@ -98,7 +46,7 @@ Name of the Secret that contains the Redis tasks password
   {{- else if .Values.tasksRedis.existingSecretName }}
     {{- .Values.tasksRedis.existingSecretName }}
   {{- else }}
-    {{- .Values.existingSecret | default (include "netbox.fullname" .) }}
+    {{- .Values.existingSecret | default (include "common.names.fullname" .) }}
   {{- end }}
 {{- end }}
 
@@ -124,7 +72,7 @@ Name of the Secret that contains the Redis cache password
   {{- else if .Values.cachingRedis.existingSecretName }}
     {{- .Values.cachingRedis.existingSecretName }}
   {{- else }}
-    {{- .Values.existingSecret | default (include "netbox.fullname" .) }}
+    {{- .Values.existingSecret | default (include "common.names.fullname" .) }}
   {{- end }}
 {{- end }}
 
@@ -149,7 +97,7 @@ Volumes that need to be mounted for .Values.extraConfig entries
 - name: extra-config-{{ $index }}
   {{- if $config.values }}
   configMap:
-    name: {{ include "netbox.fullname" $ }}
+    name: {{ include "common.names.fullname" $ }}
     items:
     - key: extra-{{ $index }}.yaml
       path: extra-{{ $index }}.yaml

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "netbox.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   {{- with .Values.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "netbox.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
 data:
   configuration.py: |-
     import re

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -2,13 +2,13 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "netbox.fullname" . }}-housekeeping
+  name: {{ include "common.names.fullname" . }}-housekeeping
   {{- with .Values.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "netbox.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: housekeeping
 spec:
   concurrencyPolicy: {{ .Values.housekeeping.concurrencyPolicy }}
@@ -19,7 +19,7 @@ spec:
   jobTemplate:
     metadata:
       labels:
-        {{- include "netbox.labels" . | nindent 8 }}
+        {{- include "common.labels.standard" . | nindent 8 }}
     spec:
       template:
         metadata:
@@ -28,7 +28,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           labels:
-            {{- include "netbox.selectorLabels" . | nindent 12 }}
+            {{- include "common.labels.matchLabels" . | nindent 12 }}
             app.kubernetes.io/component: housekeeping
             {{- with .Values.housekeeping.podLabels }}
             {{- toYaml . | nindent 12 }}
@@ -101,12 +101,12 @@ spec:
           volumes:
           - name: config
             configMap:
-              name: {{ include "netbox.fullname" . }}
+              name: {{ include "common.names.fullname" . }}
           - name: secrets
             projected:
               sources:
               - secret:
-                  name: {{ .Values.existingSecret | default (include "netbox.fullname" .) | quote }}
+                  name: {{ .Values.existingSecret | default (include "common.names.fullname" .) | quote }}
                   items:
                   # Used by our configuration
                   - key: email_password
@@ -139,14 +139,14 @@ spec:
           - name: media
             {{- if .Values.persistence.enabled }}
             persistentVolumeClaim:
-              claimName: {{ .Values.persistence.existingClaim | default (printf "%s-media" (include "netbox.fullname" .)) }}
+              claimName: {{ .Values.persistence.existingClaim | default (printf "%s-media" (include "common.names.fullname" .)) }}
             {{- else }}
             emptyDir: {}
             {{- end }}
           {{- if .Values.reportsPersistence.enabled }}
           - name: reports
             persistentVolumeClaim:
-              claimName: {{ .Values.reportsPersistence.existingClaim | default (printf "%s-reports" (include "netbox.fullname" .)) }}
+              claimName: {{ .Values.reportsPersistence.existingClaim | default (printf "%s-reports" (include "common.names.fullname" .)) }}
           {{- end }}
           {{- with .Values.housekeeping.extraVolumes }}
           {{- toYaml . | nindent 10 }}

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -1,13 +1,13 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "netbox.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   {{- with .Values.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "netbox.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: netbox
 spec:
 {{- if not .Values.autoscaling.enabled }}
@@ -15,7 +15,7 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-      {{- include "netbox.selectorLabels" . | nindent 6 }}
+      {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: netbox
   {{ if .Values.updateStrategy -}}
   strategy:
@@ -32,7 +32,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "netbox.selectorLabels" . | nindent 8 }}
+        {{- include "common.labels.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: netbox
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
@@ -164,12 +164,12 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ include "netbox.fullname" . }}
+          name: {{ include "common.names.fullname" . }}
       - name: secrets
         projected:
           sources:
           - secret:
-              name: {{ .Values.existingSecret | default (include "netbox.fullname" .) | quote }}
+              name: {{ .Values.existingSecret | default (include "common.names.fullname" .) | quote }}
               items:
               # Used by netbox-docker entry scripts
               - key: superuser_password
@@ -210,14 +210,14 @@ spec:
       - name: media
         {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim | default (printf "%s-media" (include "netbox.fullname" .)) }}
+          claimName: {{ .Values.persistence.existingClaim | default (printf "%s-media" (include "common.names.fullname" .)) }}
         {{- else }}
         emptyDir: {}
         {{- end }}
       {{- if .Values.reportsPersistence.enabled }}
       - name: reports
         persistentVolumeClaim:
-          claimName: {{ .Values.reportsPersistence.existingClaim | default (printf "%s-reports" (include "netbox.fullname" .)) }}
+          claimName: {{ .Values.reportsPersistence.existingClaim | default (printf "%s-reports" (include "common.names.fullname" .)) }}
       {{- end }}
       {{- with .Values.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/charts/netbox/templates/hpa.yaml
+++ b/charts/netbox/templates/hpa.yaml
@@ -2,19 +2,19 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "netbox.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   {{- with .Values.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "netbox.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: netbox
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "netbox.fullname" . }}
+    name: {{ include "common.names.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/charts/netbox/templates/ingress.yaml
+++ b/charts/netbox/templates/ingress.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "netbox.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "netbox.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
   {{- if or .Values.commonAnnotations .Values.ingress.annotations }}
   annotations:
     {{- with .Values.ingress.annotations }}

--- a/charts/netbox/templates/pvc-media.yaml
+++ b/charts/netbox/templates/pvc-media.yaml
@@ -2,13 +2,13 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ include "netbox.fullname" . }}-media
+  name: {{ include "common.names.fullname" . }}-media
   {{- with .Values.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "netbox.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   accessModes:
   - {{ .Values.persistence.accessMode | quote }}

--- a/charts/netbox/templates/pvc-reports.yaml
+++ b/charts/netbox/templates/pvc-reports.yaml
@@ -2,13 +2,13 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ include "netbox.fullname" . }}-reports
+  name: {{ include "common.names.fullname" . }}-reports
   {{- with .Values.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "netbox.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.reportsPersistence.accessMode | quote }}

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "netbox.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   {{- with .Values.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "netbox.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
 type: Opaque
 data:
   {{ if and (not .Values.postgresql.enabled) (not .Values.externalDatabase.existingSecretName) -}}

--- a/charts/netbox/templates/service.yaml
+++ b/charts/netbox/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "netbox.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   labels:
-    {{- include "netbox.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
   {{- if or .Values.commonAnnotations .Values.service.annotations }}
   annotations:
     {{- with .Values.service.annotations }}
@@ -24,7 +24,7 @@ spec:
     nodePort: {{ .Values.service.nodePort }}
     {{- end }}
   selector:
-    {{- include "netbox.selectorLabels" . | nindent 4 }}
+    {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: netbox
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP | quote }}

--- a/charts/netbox/templates/serviceaccount.yaml
+++ b/charts/netbox/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountT
 metadata:
   name: {{ include "netbox.serviceAccountName" . }}
   labels:
-    {{- include "netbox.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
   {{- if or .Values.commonAnnotations .Values.serviceAccount.annotations }}
   annotations:
     {{- with .Values.serviceAccount.annotations }}

--- a/charts/netbox/templates/servicemonitor.yaml
+++ b/charts/netbox/templates/servicemonitor.yaml
@@ -2,10 +2,10 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "netbox.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "netbox.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
     {{- with .Values.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -16,7 +16,7 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "netbox.selectorLabels" . | nindent 6 }}
+      {{- include "common.labels.matchLabels" . | nindent 6 }}
   endpoints:
   - port: http
     path: /metrics

--- a/charts/netbox/templates/tests/test-connection.yaml
+++ b/charts/netbox/templates/tests/test-connection.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "netbox.fullname" . }}-test-connection"
+  name: {{ printf "%s-test-connection" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   labels:
-    {{- include "netbox.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test-success
 spec:
@@ -12,7 +12,7 @@ spec:
     image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
     imagePullPolicy: {{ .Values.test.image.pullPolicy }}
     command: ['wget']
-    args: ['{{ include "netbox.fullname" . }}:{{ .Values.service.port }}']
+    args: ['{{ include "common.names.fullname" . }}:{{ .Values.service.port }}']
     {{- if .Values.test.resources }}
     resources:
       {{- toYaml .Values.test.resources | nindent 6 }}

--- a/charts/netbox/templates/worker-deployment.yaml
+++ b/charts/netbox/templates/worker-deployment.yaml
@@ -2,13 +2,13 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "netbox.fullname" . }}-worker
+  name: {{ include "common.names.fullname" . }}-worker
   {{- with .Values.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "netbox.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker
 spec:
   {{- if not .Values.worker.autoscaling.enabled }}
@@ -16,7 +16,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "netbox.selectorLabels" . | nindent 6 }}
+      {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: worker
   {{ if .Values.worker.updateStrategy -}}
   strategy:
@@ -33,7 +33,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "netbox.selectorLabels" . | nindent 8 }}
+        {{- include "common.labels.matchLabels" . | nindent 8 }}
         app.kubernetes.io/component: worker
         {{- with .Values.worker.podLabels }}
         {{- toYaml . | nindent 8 }}
@@ -106,12 +106,12 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ include "netbox.fullname" . }}
+          name: {{ include "common.names.fullname" . }}
       - name: secrets
         projected:
           sources:
           - secret:
-              name: {{ .Values.existingSecret | default (include "netbox.fullname" .) | quote }}
+              name: {{ .Values.existingSecret | default (include "common.names.fullname" .) | quote }}
               items:
               # Used by our configuration
               - key: email_password
@@ -144,14 +144,14 @@ spec:
       - name: media
         {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim | default (printf "%s-media" (include "netbox.fullname" .)) }}
+          claimName: {{ .Values.persistence.existingClaim | default (printf "%s-media" (include "common.names.fullname" .)) }}
         {{- else }}
         emptyDir: {}
         {{- end }}
       {{- if .Values.reportsPersistence.enabled }}
       - name: reports
         persistentVolumeClaim:
-          claimName: {{ .Values.reportsPersistence.existingClaim | default (printf "%s-reports" (include "netbox.fullname" .)) }}
+          claimName: {{ .Values.reportsPersistence.existingClaim | default (printf "%s-reports" (include "common.names.fullname" .)) }}
       {{- end }}
       {{- with .Values.worker.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/charts/netbox/templates/worker-hpa.yaml
+++ b/charts/netbox/templates/worker-hpa.yaml
@@ -2,19 +2,19 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "netbox.fullname" . }}-worker
+  name: {{ include "common.names.fullname" . }}-worker
   {{- with .Values.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "netbox.labels" . | nindent 4 }}
+    {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "netbox.fullname" . }}-worker
+    name: {{ include "common.names.fullname" . }}-worker
   minReplicas: {{ .Values.worker.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.worker.autoscaling.maxReplicas }}
   metrics:


### PR DESCRIPTION
This pull request suggests using [Bitnami `common` chart](https://github.com/bitnami/charts/tree/main/bitnami/common) to significantly simplify maintenance while increasing the standardization.
It could help generate proper labels, annotations, names, and attributes that match the latest Kubernetes operators expectations.

> [!note]
> This PR is only bringing a subset of the helpers Bitnami's common is provided.
> It is to ensure we agree on the principle before further implmenetation.
> 
> Additionnal helpers includes:
> * Labels & Annotations proper merging
> * Security & Resources helpers
> * Compatibility helpers

---
Direct follow up of https://github.com/netbox-community/netbox-chart/issues/162#issuecomment-2061528891