### PR TITLE
feat: add existingSecretName for email password

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -173,3 +173,14 @@ Volume mounts for .Values.extraConfig entries
   readOnly: true
 {{ end -}}
 {{- end }}
+
+{{/*
+Name of the Secret that contains the Email password
+*/}}
+{{- define "netbox.email.secret" -}}
+{{- if .Values.email.existingSecretName }}
+  {{- .Values.email.existingSecretName }}
+{{- else }}
+  {{- .Values.existingSecret | default (include "netbox.fullname" .) }}
+{{- end }}
+{{- end }}

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -109,14 +109,17 @@ spec:
                   name: {{ .Values.existingSecret | default (include "netbox.fullname" .) | quote }}
                   items:
                   # Used by our configuration
-                  - key: email_password
-                    path: email_password
                   - key: secret_key
                     path: secret_key
                   {{- if eq .Values.remoteAuth.backend "netbox.authentication.LDAPBackend" }}
                   - key: ldap_bind_password
                     path: ldap_bind_password
                   {{- end }}
+              - secret:
+                  name: {{ include "netbox.email.secret" . | quote }}
+                  items:
+                    - key: email_password
+                      path: email_password
               - secret:
                   name: {{ include "netbox.postgresql.secret" . | quote }}
                   items:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -177,14 +177,17 @@ spec:
               - key: superuser_api_token
                 path: superuser_api_token
               # Used by our configuration
-              - key: email_password
-                path: email_password
               - key: secret_key
                 path: secret_key
               {{- if eq .Values.remoteAuth.backend "netbox.authentication.LDAPBackend" }}
               - key: ldap_bind_password
                 path: ldap_bind_password
               {{- end }}
+          - secret:
+              name: {{ include "netbox.email.secret" . | quote }}
+              items:
+                - key: email_password
+                  path: email_password
           - secret:
               name: {{ include "netbox.postgresql.secret" . | quote }}
               items:

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -114,14 +114,17 @@ spec:
               name: {{ .Values.existingSecret | default (include "netbox.fullname" .) | quote }}
               items:
               # Used by our configuration
-              - key: email_password
-                path: email_password
               - key: secret_key
                 path: secret_key
               {{- if eq .Values.remoteAuth.backend "netbox.authentication.LDAPBackend" }}
               - key: ldap_bind_password
                 path: ldap_bind_password
               {{- end }}
+          - secret:
+              name: {{ include "netbox.email.secret" . | quote }}
+              items:
+                - key: email_password
+                  path: email_password
           - secret:
               name: {{ include "netbox.postgresql.secret" . | quote }}
               items:


### PR DESCRIPTION
Hello,

Context:
Onepassword operator doesn't allow empty value for a secret key (https://github.com/1Password/onepassword-operator/issues/157). I create an additional secret with empty value, but I can't add a secret name for `email_password`.

I'm also blocked with the key napalm secret on `4.1.1`, but it's look like remove the this chart.