### PR TITLE
Fix default branch for GitHub Actions workflows

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -5,10 +5,10 @@ name: Analysis
 on:
   push:
     branches:
-      - main
+      - develop
   pull_request:
     branches:
-      - main
+      - develop
   schedule:
     - cron: '43 2 * * 6'
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - develop
   pull_request:
     branches:
-      - main
+      - develop
 
 jobs:
   prepare:
@@ -45,7 +45,7 @@ jobs:
 
   release:
     name: Release
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/develop'
     uses: ./.github/workflows/release.yml
     permissions:
       contents: write


### PR DESCRIPTION
Just realized the default branch on #181 was not the correct one.
This PR fixes this.