### PR TITLE
Remove the unused secret variable for GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,10 @@ name: Release
 
 on:
   workflow_call:
-    secrets:
-      GPG_KEY_BASE64:
-        required: true
-        description: GPG key for signing
+    # secrets:
+    #   GPG_KEY_BASE64:
+    #     required: true
+    #     description: GPG key for signing
 
 jobs:
   publish:


### PR DESCRIPTION
Second fix after #181 to make GitHub Actions run.