### PR TITLE
feat: add settings for controlling http message sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The following table lists the configurable parameters for this chart and their d
 | `cors.originRegexWhitelist`                     | [CORS]: list of regex strings matching authorised origins           | `[]`                                         |
 | `csrf.cookieName`                               | Name of the CSRF authentication cookie                              | `csrftoken`                                  |
 | `csrf.trustedOrigins`                           | A list of trusted origins for unsafe (e.g. POST) requests           | `[]`                                         |
+| `dataUploadMaxMemorySize`                       | The maximum size (in bytes) of an incoming HTTP request             | `2621440`                                    |
 | `debug`                                         | Enable NetBox debugging (NOT for production use)                    | `false`                                      |
 | `defaultLanguage`                               | Set the default preferred language/locale                           | `en-us`                                      |
 | `dbWaitDebug`                                   | Show details of errors that occur when applying migrations          | `false`                                      |
@@ -185,6 +186,7 @@ The following table lists the configurable parameters for this chart and their d
 | `enforceGlobalUnique`                           | Enforce unique IP space in the global table (not in a VRF)          | `false`                                      |
 | `exemptViewPermissions`                         | A list of models to exempt from the enforcement of view permissions | `[]`                                         |
 | `fieldChoices`                                  | Configure custom choices for certain built-in fields                | `{}`                                         |
+| `fileUploadMaxMemorySize`                       | The maximum amount (in bytes) of uploaded data that will be held in memory before being written to the filesystem  | `2621440` |
 | `graphQlEnabled`                                | Enable the GraphQL API                                              | `true`                                       |
 | `httpProxies`                                   | HTTP proxies NetBox should use when sending outbound HTTP requests  | `null`                                       |
 | `internalIPs`                                   | IP addresses recognized as internal to the system                   | `['127.0.0.1', '::1']`                       |

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta2
+version: 5.0.0-beta3
 appVersion: "v3.6.4"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -109,6 +109,7 @@ data:
     CORS_ORIGIN_WHITELIST: {{ toJson .Values.cors.originWhitelist }}
     CORS_ORIGIN_REGEX_WHITELIST: {{ toJson .Values.cors.originRegexWhitelist }}
     CSRF_TRUSTED_ORIGINS: {{ toJson .Values.csrf.trustedOrigins }}
+    DATA_UPLOAD_MAX_MEMORY_SIZE: {{ int .Values.dataUploadMaxMemorySize }}
     DEBUG: {{ toJson .Values.debug }}
     DEFAULT_LANGUAGE: {{ .Values.defaultLanguage | quote }}
 
@@ -126,6 +127,7 @@ data:
     ENFORCE_GLOBAL_UNIQUE: {{ toJson .Values.enforceGlobalUnique }}
     EXEMPT_VIEW_PERMISSIONS: {{ toJson .Values.exemptViewPermissions }}
     FIELD_CHOICES: {{ toJson .Values.fieldChoices }}
+    FILE_UPLOAD_MAX_MEMORY_SIZE: {{ int .Values.fileUploadMaxMemorySize }}
     GRAPHQL_ENABLED: {{ toJson .Values.graphQlEnabled }}
     HTTP_PROXIES: {{ toJson .Values.httpProxies }}
     INTERNAL_IPS: {{ toJson .Values.internalIPs }}

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -114,6 +114,10 @@ csrf:
 # Set the default preferred language/locale
 defaultLanguage: en-us
 
+# The maximum size (in bytes) of an incoming HTTP request (i.e. GET or POST data).
+# Requests which exceed this size will raise a RequestDataTooBig exception.
+dataUploadMaxMemorySize: 2621440
+
 # Set to True to enable server debugging. WARNING: Debugging introduces a
 # substantial performance penalty and may reveal sensitive information about
 # your installation. Only enable debugging while performing testing. Never
@@ -161,6 +165,11 @@ fieldChoices: {}
   #   - [baz, Baz, blue]
   # 'dcim.Site.status+':
   #   ...
+
+# The maximum amount (in bytes) of uploaded data that will be held in memory before being written to the filesystem.
+# Changing this setting can be useful for example to be able to upload files bigger than 2.5MB to custom scripts
+# for processing.
+fileUploadMaxMemorySize: 2621440
 
 # Enable the GraphQL API
 graphQlEnabled: true


### PR DESCRIPTION
Support setting `DATA_UPLOAD_MAX_MEMORY_SIZE` and `FILE_UPLOAD_MAX_MEMORY_SIZE` in configmap.