### PR TITLE
 fix: can't evaluate field Values in type string for ingress

### DIFF
--- a/charts/netbox/templates/ingress.yaml
+++ b/charts/netbox/templates/ingress.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.ingress.enabled -}}
+{{- $fullName := include "common.names.fullname" . -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name:  {{ $fullName }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
@@ -32,7 +33,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: {{ include "common.names.fullname" . }}
+            name:  {{ $fullName }}
             port:
               name: http
       {{- else }}


### PR DESCRIPTION
When try the new version of the chart, I received, the error "can't evaluate field Values in type string for ingress".

The message is 
Manifest generation error (cached): `helm template . --name-template build --namespace netbox --kube-version 1.27 --set gke_project=fml-build-kubecore --set branch=build --set environment=build --values <path to cached source>/config/build/values.yaml <api versions removed> --include-crds` failed exit status 1: Error: template: netbox/charts/netbox/templates/ingress.yaml:35:21: executing "netbox/charts/netbox/templates/ingress.yaml" at <include "common.names.fullname" .>: error calling include: template: netbox/charts/netbox/charts/common/templates/_names.tpl:27:14: executing "common.names.fullname" at <.Values.fullnameOverride>: can't evaluate field Values in type string

Use --debug flag to render out invalid YAML


