### PR TITLE
fix: correct indentation of extraVolumeMounts

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta8
+version: 5.0.0-beta9
 appVersion: "v4.0.0"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -152,7 +152,7 @@ spec:
           subPath: superuser_api_token
           readOnly: true
         {{- if .Values.extraVolumeMounts }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 10 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 8 }}
         {{- end }}
         {{- if .Values.resources }}
         resources: {{ toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
Attempting to use `beta8` was failing with the following error:

```shell
$ helm template netbox netbox/netbox --devel --values values.yaml -s templates/deployment.yaml        
Error: YAML parse error on netbox/templates/deployment.yaml: error converting YAML to JSON: yaml: line 135: did not find expected key
```

After some troubleshooting, I worked out that this is the issue and have now successfully rendered templates locally.
