### PR TITLE
Streamline rendering for `resources`, `initContainers` and `sidecars`

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta9
+version: 5.0.0-beta12
 appVersion: "v4.0.0"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -38,9 +38,8 @@ spec:
           automountServiceAccountToken: {{ .Values.housekeeping.automountServiceAccountToken }}
           securityContext:
             {{- toYaml .Values.housekeeping.podSecurityContext | nindent 12 }}
-          {{- with .Values.housekeeping.initContainers }}
-          initContainers:
-          {{- toYaml . | nindent 10 }}
+          {{- if .Values.housekeeping.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.housekeeping.initContainers "context" $) | trim | nindent 10 }}
           {{- end }}
           containers:
           - name: {{ .Chart.Name }}-housekeeping
@@ -94,8 +93,8 @@ spec:
             {{- else if ne .Values.housekeeping.resourcesPreset "none" }}
             resources: {{- include "common.resources.preset" (dict "type" .Values.housekeeping.resourcesPreset) | nindent 14 }}
             {{- end }}
-          {{- with .Values.housekeeping.sidecars }}
-          {{- toYaml . | nindent 10 }}
+          {{- if .Values.housekeeping.sidecars }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.housekeeping.sidecars "context" $) | nindent 10 }}
           {{- end }}
           volumes:
           - name: config

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -159,8 +159,8 @@ spec:
         {{- else if ne .Values.resourcesPreset "none" }}
         resources: {{- include "common.resources.preset" (dict "type" .Values.resourcesPreset) | nindent 10 }}
         {{- end }}
-      {{- with .Values.sidecars }}
-      {{- toYaml . | nindent 6 }}
+      {{- if .Values.sidecars }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 6 }}
       {{- end }}
       volumes:
       - name: config

--- a/charts/netbox/templates/tests/test-connection.yaml
+++ b/charts/netbox/templates/tests/test-connection.yaml
@@ -14,7 +14,8 @@ spec:
     command: ['wget']
     args: ['{{ include "common.names.fullname" . }}:{{ .Values.service.port }}']
     {{- if .Values.test.resources }}
-    resources:
-      {{- toYaml .Values.test.resources | nindent 6 }}
+    resources: {{ toYaml .Values.test.resources | nindent 6 }}
+    {{- else if ne .Values.test.resourcesPreset "none" }}
+    resources: {{- include "common.resources.preset" (dict "type" .Values.test.resourcesPreset) | nindent 6 }}
     {{- end }}
   restartPolicy: Never

--- a/charts/netbox/templates/worker-deployment.yaml
+++ b/charts/netbox/templates/worker-deployment.yaml
@@ -46,9 +46,8 @@ spec:
       automountServiceAccountToken: {{ .Values.worker.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.worker.podSecurityContext | nindent 8 }}
-      {{- with .Values.worker.initContainers }}
-      initContainers:
-      {{- toYaml . | nindent 6 }}
+      {{- if .Values.worker.initContainers }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.worker.initContainers "context" $) | trim | nindent 6 }}
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-worker
@@ -102,8 +101,8 @@ spec:
         {{- else if ne .Values.worker.resourcesPreset "none" }}
         resources: {{- include "common.resources.preset" (dict "type" .Values.worker.resourcesPreset) | nindent 10 }}
         {{- end }}
-      {{- with .Values.worker.sidecars }}
-      {{- toYaml . | nindent 6 }}
+      {{- if .Values.worker.sidecars }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.worker.sidecars "context" $) | nindent 6 }}
       {{- end }}
       volumes:
       - name: config


### PR DESCRIPTION
This PR enforces template rendering for `resources`, `initContainers` and `sidecars` accross the chart.
This would make it less prone to configuration/user input errors.