### PR TITLE
Fix indent for housekeeping CronJob imagePullSecrets

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta12
+version: 5.0.0-beta13
 appVersion: "v4.0.0"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -33,7 +33,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
         spec:
-          {{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) | nindent 6 }}
+          {{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) | nindent 10 }}
           serviceAccountName: {{ include "netbox.serviceAccountName" . }}
           automountServiceAccountToken: {{ .Values.housekeeping.automountServiceAccountToken }}
           {{- if .Values.housekeeping.podSecurityContext.enabled }}


### PR DESCRIPTION
The housekeeping CronJob produces an invalid spec when image pull secrets are set as the indent is wrong.