### PR TITLE
add a dot to the beta so it sorts numerically

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta14
+version: 5.0.0-beta.15
 appVersion: "v4.0.0"
 type: application
 kubeVersion: ^1.25.0-0


### PR DESCRIPTION
I found when trying to depend on this chart that `helm dep update` didn't consider beta14 higher than beta9. This should hopefully make it update properly.