### PR TITLE
Use GitHub Container Registry as default registry for main image

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.16
+version: 5.0.0-beta.18
 appVersion: "v4.0.3"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -53,8 +53,8 @@ extraDeploy: []
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ##
 image:
-  registry: docker.io
-  repository: netboxcommunity/netbox
+  registry: ghcr.io
+  repository: netbox-community/netbox
   pullPolicy: IfNotPresent
   ## Defaults to '{{ .Chart.AppVersion }}'
   ##


### PR DESCRIPTION
This PR is switching the default registry for Netbox image from Docker Hub (`docker.io`) to GitHub Container Registry (`ghcr.io`).

The motivations are the following:
* GHCR is 100% free of use for egress, with almost nonexistent limits compared to Docker Hub. This helps to reduce rate limit errors of large deployments.
* Download speed is slightly better, especially for development in the GitHub context (mainly GitHub Codespaces and GitHub Actions)
* Container images management on GHCR is more transparent for other repositories as this one. 
* The content is the same.