### PR TITLE
Split secrets values across segmented secrets instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The following table lists the configurable parameters for this chart and their d
 | `superuser.email`                               | Email address for the initial super-user account                    | `admin@example.com`                          |
 | `superuser.password`                            | Password for the initial super-user account                         | `admin`                                      |
 | `superuser.apiToken`                            | API token created for the initial super-user account                | `0123456789abcdef0123456789abcdef01234567`   |
+| `superuser.existingSecret`                      | Use an existing Kubernetes `Secret` for secret values               | `""`                                         |
 | `skipStartupScripts`                            | Skip [netbox-docker startup scripts]                                | `true`                                       |
 | `allowedHosts`                                  | List of valid FQDNs for this NetBox instance                        | `["*"]`                                      |
 | `admins`                                        | List of admins to email about critical errors                       | `[]`                                         |
@@ -470,19 +471,40 @@ worker:
 ## Using an Existing Secret
 
 Rather than specifying passwords and secrets as part of the Helm release values,
-you may pass these to NetBox using a pre-existing `Secret` resource. When using
+you may pass these to NetBox using pre-existing `Secret` resources. When using
 this, the `Secret` must contain the following keys:
+
+### Superuser secret
+
+Type: `kubernetes.io/basic-auth`
+
+| Key                    | Description                                                   | Required?                                                                                         |
+| -----------------------|---------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| `username`             | Username for the initial super-user account                   | Yes                                                                                               |
+| `password`             | Password for the initial super-user account                   | Yes                                                                                               |
+| `email`                | Email address for the initial super-user account              | Yes                                                                                               |
+| `api_token`            | API token created for the initial super-user account          | Yes                                                                                               |
+
+### Config secret
+
+| Key                    | Description                                                   | Required?                                                                                         |
+| -----------------------|---------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| `email_password`       | SMTP user password                                            | Yes, but the value may be left blank if not required                                              |
+| `ldap_bind_password`   | Password for LDAP bind DN                                     | If `remoteAuth.enabled` is `true` and `remoteAuth.backend` is `netbox.authentication.LDAPBackend` |
+| `secret_key`           | Django secret key used for sessions and password reset tokens | Yes                                                                                               |
+
+### PostgreSQL secret
 
 | Key                    | Description                                                   | Required?                                                                                         |
 | -----------------------|---------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | `db_password`          | The password for the external PostgreSQL database             | If `postgresql.enabled` is `false` and `externalDatabase.existingSecretName` is unset             |
-| `email_password`       | SMTP user password                                            | Yes, but the value may be left blank if not required                                              |
-| `ldap_bind_password`   | Password for LDAP bind DN                                     | If `remoteAuth.enabled` is `true` and `remoteAuth.backend` is `netbox.authentication.LDAPBackend` |
+
+### Redis secret
+
+| Key                    | Description                                                   | Required?                                                                                         |
+| -----------------------|---------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | `redis_tasks_password` | Password for the external Redis tasks database                | If `redis.enabled` is `false` and `tasksRedis.existingSecretName` is unset                        |
 | `redis_cache_password` | Password for the external Redis cache database                | If `redis.enabled` is `false` and `cachingRedis.existingSecretName` is unset                      |
-| `secret_key`           | Django secret key used for sessions and password reset tokens | Yes                                                                                               |
-| `superuser_password`   | Password for the initial super-user account                   | Yes                                                                                               |
-| `superuser_api_token`  | API token created for the initial super-user account          | Yes                                                                                               |
 
 ## Using extraConfig for S3 storage configuration
 

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.16
+version: 5.0.0-beta.19
 appVersion: "v4.0.3"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/_helpers.tpl
+++ b/charts/netbox/templates/_helpers.tpl
@@ -36,10 +36,8 @@ Name of the Secret that contains the PostgreSQL password
 {{- define "netbox.postgresql.secret" -}}
   {{- if .Values.postgresql.enabled }}
     {{- include "postgresql.v1.secretName" .Subcharts.postgresql -}}
-  {{- else if .Values.externalDatabase.existingSecretName }}
-    {{- .Values.externalDatabase.existingSecretName }}
   {{- else }}
-    {{- .Values.existingSecret | default (include "common.names.fullname" .) }}
+    {{ include "common.secrets.name" (dict "existingSecret" .Values.externalDatabase.existingSecretName "defaultNameSuffix" "postgresql" "context" $) }}
   {{- end }}
 {{- end }}
 
@@ -62,10 +60,8 @@ Name of the Secret that contains the Redis tasks password
 {{- define "netbox.tasksRedis.secret" -}}
   {{- if .Values.redis.enabled }}
     {{- include "redis.secretName" .Subcharts.redis -}}
-  {{- else if .Values.tasksRedis.existingSecretName }}
-    {{- .Values.tasksRedis.existingSecretName }}
   {{- else }}
-    {{- .Values.existingSecret | default (include "common.names.fullname" .) }}
+    {{ include "common.secrets.name" (dict "existingSecret" .Values.tasksRedis.existingSecretName "defaultNameSuffix" "redis" "context" $) }}
   {{- end }}
 {{- end }}
 
@@ -88,10 +84,8 @@ Name of the Secret that contains the Redis cache password
 {{- define "netbox.cachingRedis.secret" -}}
   {{- if .Values.redis.enabled }}
     {{- include "redis.secretName" .Subcharts.redis -}}
-  {{- else if .Values.cachingRedis.existingSecretName }}
-    {{- .Values.cachingRedis.existingSecretName }}
   {{- else }}
-    {{- .Values.existingSecret | default (include "common.names.fullname" .) }}
+    {{ include "common.secrets.name" (dict "existingSecret" .Values.cachingRedis.existingSecretName "defaultNameSuffix" "redis" "context" $) }}
   {{- end }}
 {{- end }}
 

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -72,9 +72,15 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: SUPERUSER_NAME
-          value: {{ .Values.superuser.name | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "common.secrets.name" (dict "existingSecret" .Values.superuser.existingSecret "defaultNameSuffix" "superuser" "context" $) }}
+              key: username
         - name: SUPERUSER_EMAIL
-          value: {{ .Values.superuser.email | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "common.secrets.name" (dict "existingSecret" .Values.superuser.existingSecret "defaultNameSuffix" "superuser" "context" $) }}
+              key: email
         - name: SKIP_STARTUP_SCRIPTS
           value: {{ .Values.skipStartupScripts | quote }}
         {{- if .Values.dbWaitDebug }}
@@ -173,14 +179,8 @@ spec:
         projected:
           sources:
           - secret:
-              name: {{ .Values.existingSecret | default (include "common.names.fullname" .) | quote }}
+              name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "defaultNameSuffix" "config" "context" $) }}
               items:
-              # Used by netbox-docker entry scripts
-              - key: superuser_password
-                path: superuser_password
-              - key: superuser_api_token
-                path: superuser_api_token
-              # Used by our configuration
               - key: email_password
                 path: email_password
               - key: secret_key
@@ -191,6 +191,13 @@ spec:
                 path: ldap_bind_password
               {{- end }}
               {{- end }}
+          - secret:
+              name: {{ include "common.secrets.name" (dict "existingSecret" .Values.superuser.existingSecret "defaultNameSuffix" "superuser" "context" $) }}
+              items:
+              - key: password
+                path: superuser_password
+              - key: api_token
+                path: superuser_api_token
           - secret:
               name: {{ include "netbox.postgresql.secret" . | quote }}
               items:

--- a/charts/netbox/templates/postgresql-secret.yaml
+++ b/charts/netbox/templates/postgresql-secret.yaml
@@ -1,0 +1,14 @@
+{{- if not (or .Values.postgresql.enabled  .Values.externalDatabase.existingSecretName) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.secrets.name" (dict "defaultNameSuffix" "postgresql" "context" $) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  db_password: {{ .Values.externalDatabase.password | b64enc | quote }}
+{{- end -}}

--- a/charts/netbox/templates/redis-secret.yaml
+++ b/charts/netbox/templates/redis-secret.yaml
@@ -1,0 +1,19 @@
+{{- if not (or .Values.redis.enabled (and .Values.tasksRedis.existingSecretName .Values.cachingRedis.existingSecretName)) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.secrets.name" (dict "defaultNameSuffix" "redis" "context" $) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  {{ if not .Values.tasksRedis.existingSecretName -}}
+  redis_tasks_password: {{ .Values.tasksRedis.password | b64enc | quote }}
+  {{ end -}}
+  {{ if not .Values.cachingRedis.existingSecretName -}}
+  redis_cache_password: {{ .Values.cachingRedis.password | b64enc | quote }}
+  {{ end -}}
+{{- end -}}

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.secrets.name" (dict "context" $) }}
+  name: {{ include "common.secrets.name" (dict "defaultNameSuffix" "config" "context" $) }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
@@ -10,19 +10,8 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{ if and (not .Values.postgresql.enabled) (not .Values.externalDatabase.existingSecretName) -}}
-  db_password: {{ .Values.externalDatabase.password | b64enc | quote }}
-  {{ end -}}
   email_password: {{ .Values.email.password | b64enc | quote }}
-  {{ if and (not .Values.redis.enabled) (not .Values.tasksRedis.existingSecretName) -}}
-  redis_tasks_password: {{ .Values.tasksRedis.password | b64enc | quote }}
-  {{ end -}}
-  {{ if and (not .Values.redis.enabled) (not .Values.cachingRedis.existingSecretName) -}}
-  redis_cache_password: {{ .Values.cachingRedis.password | b64enc | quote }}
-  {{ end -}}
-  secret_key: {{ .Values.secretKey | default (randAscii 60) | b64enc }}
-  superuser_password: {{ .Values.superuser.password | default (randAlphaNum 16) | b64enc }}
-  superuser_api_token: {{ .Values.superuser.apiToken | default uuidv4 | b64enc }}
+  secret_key: {{ .Values.secretKey | default (randAscii 60) | b64enc | quote }}
   {{- range .Values.remoteAuth.backends }}
   {{- if eq . "netbox.authentication.LDAPBackend" }}
   ldap_bind_password: {{ $.Values.remoteAuth.ldap.bindPassword | b64enc | quote }}

--- a/charts/netbox/templates/superuser-secrets.yaml
+++ b/charts/netbox/templates/superuser-secrets.yaml
@@ -1,0 +1,17 @@
+{{- if not .Values.superuser.existingSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.secrets.name" (dict "defaultNameSuffix" "superuser" "context" $) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/basic-auth
+data:
+  username: {{ .Values.superuser.name | default "admin" | b64enc | quote }}
+  password: {{ .Values.superuser.password | default (randAlphaNum 16) | b64enc | quote }}
+  email: {{ .Values.superuser.email | b64enc | quote }}
+  api_token: {{ .Values.superuser.apiToken | default uuidv4 | b64enc | quote }}
+{{- end -}}

--- a/charts/netbox/templates/worker-deployment.yaml
+++ b/charts/netbox/templates/worker-deployment.yaml
@@ -115,9 +115,8 @@ spec:
         projected:
           sources:
           - secret:
-              name: {{ .Values.existingSecret | default (include "common.names.fullname" .) | quote }}
+              name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "defaultNameSuffix" "config" "context" $) }}
               items:
-              # Used by our configuration
               - key: email_password
                 path: email_password
               - key: secret_key
@@ -128,6 +127,13 @@ spec:
                 path: ldap_bind_password
               {{- end }}
               {{- end }}
+          - secret:
+              name: {{ include "common.secrets.name" (dict "existingSecret" .Values.superuser.existingSecret "defaultNameSuffix" "superuser" "context" $) }}
+              items:
+              - key: password
+                path: superuser_password
+              - key: api_token
+                path: superuser_api_token
           - secret:
               name: {{ include "netbox.postgresql.secret" . | quote }}
               items:

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -79,6 +79,7 @@ superuser:
   email: admin@example.com
   password: ""
   apiToken: ""
+  existingSecret: ""
 
 # Skip the netbox-docker startup scripts which can pre-populate objects into a
 # fresh NetBox installation. By default these do nothing, but they take a while


### PR DESCRIPTION
This PR aims to facilitate secret values management.
By splitting them into per-domain secret instances, proper management policies can be applied.
It should also help to have consistent secrets in the time and across deployments, and ease secret instance deprecation.