### PR TITLE
Bump dependencies

### DIFF
--- a/charts/netbox/Chart.lock
+++ b/charts/netbox/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
+  version: 2.19.3
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.4.6
+  version: 15.5.0
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.19.4
-digest: sha256:aca8217d7972de1fa6676ab69d10ef43ba8ec7f2f409cce620a960358d8f4b7d
-generated: "2024-05-02T15:26:40.653130602Z"
+  version: 19.5.0
+digest: sha256:96fa2a4ce742f94339c229261ae78bc81b9842d76d6d296a29cda6d3e5d2bd26
+generated: "2024-05-30T17:42:46.894553667Z"

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: redis
-    version: ^18.19.4
+    version: ^19.5.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled
 annotations:

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.18
+version: 5.0.0-beta.21
 appVersion: "v4.0.3"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
     tags:
       - bitnami-common
   - name: postgresql
-    version: ^13.4.6
+    version: ^15.5.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: redis


### PR DESCRIPTION
* Redis upgrade guide: https://github.com/bitnami/charts/tree/b21c6f4ad75320fa613d6f9d0523d696ae241959/bitnami/redis#to-1900
* PostgreSQL upgrade guide: https://github.com/bitnami/charts/tree/b21c6f4ad75320fa613d6f9d0523d696ae241959/bitnami/postgresql#to-1500

---

@RangerRick Would it be possible to enable Renovate app? It would do that work automatically.
https://github.com/apps/renovate