### PR TITLE
Fix Renovate config for OCI repositories

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":disableDependencyDashboard"
   ],
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
   "packageRules": [
+    {
+      "matchManagers": ["helmv3"],
+      "versioning": "helm"
+    },
     {
       "matchDatasources": ["helm"],
       "matchUpdateTypes": ["minor", "patch"],
@@ -23,8 +27,9 @@
       "automerge": true
     }
   ],
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["(^|/)Chart.yaml$"],
       "matchStrings": [
         "\\nname: (?<depName>.*?)\\n",


### PR DESCRIPTION
This is quite a workaround, but makes sure to follow Helm chart recommendations on versioning ranges.

Also migrate configuration to the latest schema.