### PR TITLE
Use proper Renovate manager matcher

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,12 +12,12 @@
       "versioning": "helm"
     },
     {
-      "matchDatasources": ["helm"],
+      "matchManagers": ["helmv3"],
       "matchUpdateTypes": ["minor", "patch"],
       "bumpVersion": "patch"
     },
     {
-      "matchDatasources": ["helm"],
+      "matchManagers": ["helmv3"],
       "matchUpdateTypes": ["major"],
       "bumpVersion": "minor"
     },


### PR DESCRIPTION
This fixes the missing chart version bump when a dependency is updated.

> [!tip]
> I'd recommend not to merge before chart 5.0.0 is published.