### PR TITLE
Setup all Kubernetes probes for dep stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,12 +298,22 @@ The following table lists the configurable parameters for this chart and their d
 | `schedulerName`                                 | Name of the k8s scheduler (other than default) for pods             | `""`                                         |
 | `terminationGracePeriodSeconds`                 | Seconds pods need to terminate gracefully                           | `""`                                         |
 | `topologySpreadConstraints`                     | Configure Pod Topology Spread Constraints for NetBox                | `[]`                                         |
+| `livenessProbe.enabled`                         | Enable Kubernetes livenessProbe, see [liveness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command) | *see `values.yaml`* |
+| `livenessProbe.initialDelaySeconds`             | Number of seconds                                                   |  *see `values.yaml`*                         |
+| `livenessProbe.timeoutSeconds`                  | Number of seconds                                                   |  *see `values.yaml`*                         |
+| `livenessProbe.periodSeconds`                   | Number of seconds                                                   |  *see `values.yaml`*                         |
+| `livenessProbe.successThreshold`                | Number of seconds                                                   |  *see `values.yaml`*                         |
 | `readinessProbe.enabled`                        | Enable Kubernetes readinessProbe, see [readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes) | *see `values.yaml`* |
 | `readinessProbe.initialDelaySeconds`            | Number of seconds                                                   |  *see `values.yaml`*                         |
 | `readinessProbe.timeoutSeconds`                 | Number of seconds                                                   |  *see `values.yaml`*                         |
 | `readinessProbe.periodSeconds`                  | Number of seconds                                                   |  *see `values.yaml`*                         |
 | `readinessProbe.successThreshold`               | Number of seconds                                                   |  *see `values.yaml`*                         |
 | `lifecycleHooks`                                | Automate configuration before or after container startup            | `{}`                                         |
+| `startupProbe.enabled`                          | Enable Kubernetes startupProbe, see [startup probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes) | *see `values.yaml`* |
+| `startupProbe.initialDelaySeconds`              | Number of seconds                                                   |  *see `values.yaml`*                         |
+| `startupProbe.timeoutSeconds`                   | Number of seconds                                                   |  *see `values.yaml`*                         |
+| `startupProbe.periodSeconds`                    | Number of seconds                                                   |  *see `values.yaml`*                         |
+| `startupProbe.successThreshold`                 | Number of seconds                                                   |  *see `values.yaml`*                         |
 | `init.image.repository`                         | Init container image repository                                     | `busybox`                                    |
 | `init.image.tag`                                | Init container image tag                                            | `1.32.1`                                     |
 | `init.image.pullPolicy`                         | Init container image pull policy                                    | `IfNotPresent`                               |

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.59
+version: 5.0.0-beta.60
 appVersion: "v4.0.8"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -103,8 +103,13 @@ spec:
         - name: http
           containerPort: 8080
           protocol: TCP
-        {{- if .Values.readinessProbe.enabled }}
-        readinessProbe:
+        - name: nginx-status
+          containerPort: 8081
+          protocol: TCP
+        {{- if .Values.customLivenessProbe }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 10 }}
+        {{- else if .Values.livenessProbe.enabled }}
+        livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 10 }}
           httpGet:
             path: /{{ .Values.basePath }}login/
             port: http
@@ -113,10 +118,27 @@ spec:
             - name: Host
               value: {{ (index .Values.allowedHosts 0) | quote }}
             {{- end }}
-          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.readinessProbe.successThreshold }}
-          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+        {{- end }}
+        {{- if .Values.customLivenessProbe }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 10 }}
+        {{- else if .Values.readinessProbe.enabled }}
+        readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 10 }}
+          httpGet:
+            path: /{{ .Values.basePath }}login/
+            port: http
+            {{- if (not (eq (index .Values.allowedHosts 0) "*")) }}
+            httpHeaders:
+            - name: Host
+              value: {{ (index .Values.allowedHosts 0) | quote }}
+            {{- end }}
+        {{- end }}
+        {{- if .Values.customStartupProbe }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 10 }}
+        {{- else if .Values.startupProbe.enabled }}
+        startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 10 }}
+          httpGet:
+            path: /status/applications/netbox/processes/running
+            port: nginx-status
         {{- end }}
         {{- if .Values.lifecycleHooks }}
         lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 10 }}

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -737,6 +737,22 @@ securityContext:
 ## @param automountServiceAccountToken Mount Service Account token in pod
 ##
 automountServiceAccountToken: false
+## Configure extra options for liveness probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param livenessProbe.enabled Enable livenessProbe
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1
 ## Configure extra options for readiness probe
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 ## @param readinessProbe.enabled Enable readinessProbe
@@ -753,6 +769,31 @@ readinessProbe:
   periodSeconds: 10
   failureThreshold: 3
   successThreshold: 1
+## Configure extra options for startupProbe probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param startupProbe.enabled Enable startupProbe
+## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+## @param startupProbe.periodSeconds Period seconds for startupProbe
+## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+## @param startupProbe.failureThreshold Failure threshold for startupProbe
+## @param startupProbe.successThreshold Success threshold for startupProbe
+##
+startupProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 10
+  successThreshold: 1
+## @param customLivenessProbe Override default liveness probe for containers
+##
+customLivenessProbe: {}
+## @param customReadinessProbe Override default readiness probe for containers
+##
+customReadinessProbe: {}
+## @param customStartupProbe Override default startup probe for containers
+##
+customStartupProbe: {}
 ## @param lifecycleHooks for containers to automate configuration before or after startup
 ##
 lifecycleHooks: {}


### PR DESCRIPTION
This aims to add all the necessary probes to ensure stable deployments.
It would have been great to have an alternative probe with an exec scheme instead, bot Netbox does not seem to provide status check via CLI.

Also, add the customization capability, so users can set up their probes based on plugins, for example.

Fixes #100 

> [!note]
> Upgrade test fail as it would require major version bump