### PR TITLE
Allow overriding the housekeeping command to shut down DB sidecar

### DIFF
--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -49,9 +49,7 @@ spec:
             {{- end }}
             image: {{ include "netbox.image" . | quote }}
             command:
-            - /opt/netbox/venv/bin/python
-            - /opt/netbox/netbox/manage.py
-            - housekeeping
+            {{- .Values.housekeeping.command | toYaml | nindent 14 }}
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             {{- with .Values.housekeeping.extraEnvs }}
             env:

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -1125,6 +1125,16 @@ housekeeping:
   ## @param housekeeping.failedHistoryLimit Number of failed finished jobs to retain
   ##
   failedHistoryLimit: 5
+  ## @param housekeeping.command The command to execute in the housekeeping job
+  ## To append another command, in order to shut down a DB sidecar container, use something like
+  ##   - /bin/bash
+  ##   - -c
+  ##   - "/opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py housekeeping && curl -X POST http://localhost:9190/quitquitquit"
+  ##
+  command:
+    - /opt/netbox/venv/bin/python
+    - /opt/netbox/netbox/manage.py
+    - housekeeping
   ## @param housekeeping.podAnnotations Pod annotations
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -1126,10 +1126,12 @@ housekeeping:
   ##
   failedHistoryLimit: 5
   ## @param housekeeping.command The command to execute in the housekeeping job
-  ## To append another command, in order to shut down a DB sidecar container, use something like
+  ## To append another command, e.g. in order to shut down a DB sidecar container, use something like
   ##   - /bin/bash
   ##   - -c
-  ##   - "/opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py housekeeping && curl -X POST http://localhost:9190/quitquitquit"
+  ##   - >
+  ##     /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py housekeeping
+  ##     && curl -X POST http://localhost:9190/quitquitquit"
   ##
   command:
     - /opt/netbox/venv/bin/python


### PR DESCRIPTION
Salve, we use Google cloud-sql-proxy sidecar to enable an externalDatabase connection.

When the housekeeping job ran to completion this sidecar keeps running forever.

In this PR we added a way to append our own command to shut down this sidecar with the /quitquitquit endpoint, which was added to Istio and also cloud-sql-proxy.