### PR TITLE
Fix `allowedHostsIncludesPodIP`

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.34
+version: 5.0.0-beta.35
 appVersion: "v4.0.5"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.35
+version: 5.0.0-beta.36
 appVersion: "v4.0.5"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -69,7 +69,7 @@ data:
     REDIS['caching']['SENTINELS'] = [tuple(x.split(r":")) for x in REDIS['caching']['SENTINELS']]
     {{- end }}
 
-    {{- if .Values.allowedHostsIncludesPodIp }}
+    {{- if .Values.allowedHostsIncludesPodIP }}
     ALLOWED_HOSTS.append(os.getenv("POD_IP"))
     {{- end }}
 

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
     from pathlib import Path
 
     import yaml
+    import os
 
 
     def _deep_merge(source, destination):

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -92,12 +92,12 @@ spec:
         {{- with .Values.extraEnvs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if .Values.allowedHostsIncludesPodIp }}
-         - name: POD_IP
-           valueFrom:
-             fieldRef:
-               apiVersion: v1
-               fieldPath: status.podIP
+        {{- if .Values.allowedHostsIncludesPodIP }}
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
         {{- end }}
         ports:
         - name: http


### PR DESCRIPTION
Reference: 

* Closes #254

Currently, `allowedHostsIncludesPodIP ` does not work as intended due to incorrect capitalization and an indentation mistake.