### PR TITLE
Fix deployment issue if script persistence is enabled

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.38
+version: 5.0.0-beta.39
 appVersion: "v4.0.5"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -152,6 +152,11 @@ spec:
             persistentVolumeClaim:
               claimName: {{ .Values.reportsPersistence.existingClaim | default (printf "%s-reports" (include "common.names.fullname" .)) }}
           {{- end }}
+          {{- if .Values.scriptsPersistence.enabled }}
+          - name: scripts
+            persistentVolumeClaim:
+              claimName: {{ .Values.scriptsPersistence.existingClaim | default (printf "%s-scripts" (include "common.names.fullname" .)) }}
+          {{- end }}
           {{- with .Values.housekeeping.extraVolumes }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/netbox/templates/worker-deployment.yaml
+++ b/charts/netbox/templates/worker-deployment.yaml
@@ -170,6 +170,11 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.reportsPersistence.existingClaim | default (printf "%s-reports" (include "common.names.fullname" .)) }}
       {{- end }}
+      {{- if .Values.scriptsPersistence.enabled }}
+      - name: scripts
+        persistentVolumeClaim:
+          claimName: {{ .Values.scriptsPersistence.existingClaim | default (printf "%s-scripts" (include "common.names.fullname" .)) }}
+      {{- end }}
       {{- with .Values.worker.extraVolumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
This PR fixes issue #261 

# Issue
---
Deploy the helm chart with `scriptsPersistence.enable: true` results in `netbox-worker` and `housekeeping` (cronjob) generated with illegal k8s yaml spec

# Fix
---
Fix the `cronjob.yaml` and `worker-deployment.yaml` helm templates.