### PR TITLE
Take all imagePullSecrets in the worker deployment into account

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.51
+version: 5.0.0-beta.52
 appVersion: "v4.0.7"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/worker-deployment.yaml
+++ b/charts/netbox/templates/worker-deployment.yaml
@@ -39,10 +39,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-      {{- toYaml . | nindent 6 }}
-      {{- end }}
+      {{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) | nindent 6 }}
       serviceAccountName: {{ include "netbox.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.worker.automountServiceAccountToken }}
       {{- if .Values.worker.podSecurityContext.enabled }}


### PR DESCRIPTION
With this adjustments the `global.imagePullSecrets` and the `image.pullSecrets` will fill the `imagePullSecrets` in the worker deployment manifest.
Also now the filling of the `imagePullSecrets` in the worker deployment will have the same behavior as in the netbox deployment and the cronjob manifest.