### PR TITLE
Add support for bringing your own LDAP CA certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ The following table lists the configurable parameters for this chart and their d
 | `remoteAuth.ldap.serverUri`                     | see [django-auth-ldap](https://django-auth-ldap.readthedocs.io)     | `""`                                         |
 | `remoteAuth.ldap.startTls`                      | if StarTLS should be used                                           | *see values.yaml*                            |
 | `remoteAuth.ldap.ignoreCertErrors`              | if Certificate errors should be ignored                             | *see values.yaml*                            |
-| `remoteAuth.ldap.caCertFile`                    | Path to CA certificate file                                         | *see auth.md*                                |
 | `remoteAuth.ldap.caCertData`                    | CA certificate data                                                 | *see auth.md*                                |
 | `remoteAuth.ldap.bindDn`                        | Distinguished Name to bind with                                     | `""`                                         |
 | `remoteAuth.ldap.bindPassword`                  | Password for bind DN                                                | `""`                                         |

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ The following table lists the configurable parameters for this chart and their d
 | `remoteAuth.ldap.serverUri`                     | see [django-auth-ldap](https://django-auth-ldap.readthedocs.io)     | `""`                                         |
 | `remoteAuth.ldap.startTls`                      | if StarTLS should be used                                           | *see values.yaml*                            |
 | `remoteAuth.ldap.ignoreCertErrors`              | if Certificate errors should be ignored                             | *see values.yaml*                            |
+| `remoteAuth.ldap.caCertFile`                    | Path to CA certificate file                                         | *see auth.md*                                |
+| `remoteAuth.ldap.caCertData`                    | CA certificate data                                                 | *see auth.md*                                |
 | `remoteAuth.ldap.bindDn`                        | Distinguished Name to bind with                                     | `""`                                         |
 | `remoteAuth.ldap.bindPassword`                  | Password for bind DN                                                | `""`                                         |
 | `remoteAuth.ldap.userDnTemplate`                | see [AUTH_LDAP_USER_DN_TEMPLATE](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-user-dn-template) | *see values.yaml* |

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.62
+version: 5.0.0-beta.63
 appVersion: "v4.0.8"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -307,10 +307,10 @@ data:
     AUTH_LDAP_MIRROR_GROUPS: {{ toJson $.Values.remoteAuth.ldap.mirrorGroups }}
     AUTH_LDAP_MIRROR_GROUPS_EXCEPT: {{ toJson $.Values.remoteAuth.ldap.mirrorGroupsExcept }}
     AUTH_LDAP_CACHE_TIMEOUT: {{ int $.Values.remoteAuth.ldap.cacheTimeout }}
-  {{- end }}
   {{- if .Values.remoteAuth.ldap.caCertData }}
   ldap_ca.crt: |-
-    {{ .Values.remoteAuth.ldap.caCertData | nindent 2 }}
+    {{- toYaml .Values.remoteAuth.ldap.caCertData | nindent 4 }}
+  {{- end }}
   {{- end }}
   {{- end }}
   {{- if .Values.overrideUnitConfig }}

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -293,6 +293,7 @@ data:
     AUTH_LDAP_BIND_DN: {{ $.Values.remoteAuth.ldap.bindDn | quote }}
     AUTH_LDAP_START_TLS: {{ toJson $.Values.remoteAuth.ldap.startTls }}
     LDAP_IGNORE_CERT_ERRORS: {{ toJson $.Values.remoteAuth.ldap.ignoreCertErrors }}
+    LDAP_CA_CERT_FILE: {{ $.Values.remoteAuth.ldap.caCertFile | quote }}
     AUTH_LDAP_USER_DN_TEMPLATE: {{ default nil $.Values.remoteAuth.ldap.userDnTemplate }}
     AUTH_LDAP_USER_SEARCH_BASEDN: {{ $.Values.remoteAuth.ldap.userSearchBaseDn | quote }}
     AUTH_LDAP_USER_SEARCH_ATTR: {{ $.Values.remoteAuth.ldap.userSearchAttr | quote }}
@@ -304,6 +305,10 @@ data:
     AUTH_LDAP_MIRROR_GROUPS: {{ toJson $.Values.remoteAuth.ldap.mirrorGroups }}
     AUTH_LDAP_MIRROR_GROUPS_EXCEPT: {{ toJson $.Values.remoteAuth.ldap.mirrorGroupsExcept }}
     AUTH_LDAP_CACHE_TIMEOUT: {{ int $.Values.remoteAuth.ldap.cacheTimeout }}
+  {{- end }}
+  {{- if .Values.remoteAuth.ldap.caCertData }}
+  ldap_ca.crt: |-
+    {{ .Values.remoteAuth.ldap.caCertData | nindent 2 }}
   {{- end }}
   {{- end }}
   {{- if .Values.overrideUnitConfig }}

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -293,7 +293,9 @@ data:
     AUTH_LDAP_BIND_DN: {{ $.Values.remoteAuth.ldap.bindDn | quote }}
     AUTH_LDAP_START_TLS: {{ toJson $.Values.remoteAuth.ldap.startTls }}
     LDAP_IGNORE_CERT_ERRORS: {{ toJson $.Values.remoteAuth.ldap.ignoreCertErrors }}
-    LDAP_CA_CERT_FILE: {{ $.Values.remoteAuth.ldap.caCertFile | quote }}
+    {{- if .Values.remoteAuth.ldap.caCertData }}
+    LDAP_CA_CERT_FILE: /etc/netbox/config/ldap/ldap_ca.crt
+    {{- end }}
     AUTH_LDAP_USER_DN_TEMPLATE: {{ default nil $.Values.remoteAuth.ldap.userDnTemplate }}
     AUTH_LDAP_USER_SEARCH_BASEDN: {{ $.Values.remoteAuth.ldap.userSearchBaseDn | quote }}
     AUTH_LDAP_USER_SEARCH_ATTR: {{ $.Values.remoteAuth.ldap.userSearchAttr | quote }}

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -70,6 +70,12 @@ spec:
               mountPath: /etc/netbox/config/ldap/ldap_config.py
               subPath: ldap_config.py
               readOnly: true
+            {{- if .Values.remoteAuth.ldap.caCertData }}
+            - name: config
+              mountPath: /etc/netbox/config/ldap/ldap_ca.crt
+              subPath: ldap_ca.crt
+              readOnly: true
+            {{- end }}
             {{- end }}
             {{- end }}
             - name: config

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -160,6 +160,12 @@ spec:
           mountPath: /etc/netbox/config/ldap/ldap_config.py
           subPath: ldap_config.py
           readOnly: true
+        {{- if .Values.remoteAuth.ldap.caCertData }}
+        - name: config
+          mountPath: /etc/netbox/config/ldap/ldap_ca.crt
+          subPath: ldap_ca.crt
+          readOnly: true
+        {{- end }}
         {{- end }}
         {{- end }}
         - name: config

--- a/charts/netbox/templates/worker-deployment.yaml
+++ b/charts/netbox/templates/worker-deployment.yaml
@@ -76,6 +76,12 @@ spec:
           mountPath: /etc/netbox/config/ldap/ldap_config.py
           subPath: ldap_config.py
           readOnly: true
+        {{- if .Values.remoteAuth.ldap.caCertData }}
+        - name: config
+          mountPath: /etc/netbox/config/ldap/ldap_ca.crt
+          subPath: ldap_ca.crt
+          readOnly: true
+        {{- end }}
         {{- end }}
         {{- end }}
         - name: config

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -356,7 +356,6 @@ remoteAuth:
   #   serverUri: 'ldap://domain.com'
   #   startTls: true
   #   ignoreCertErrors: false
-  #   caCertFile: ''
   #   caCertData: ''
   #   bindDn: 'CN=Netbox,OU=EmbeddedDevices,OU=MyCompany,DC=domain,dc=com'
   #   bindPassword: 'TopSecretPassword'

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -356,6 +356,8 @@ remoteAuth:
   #   serverUri: 'ldap://domain.com'
   #   startTls: true
   #   ignoreCertErrors: false
+  #   caCertFile: ''
+  #   caCertData: ''
   #   bindDn: 'CN=Netbox,OU=EmbeddedDevices,OU=MyCompany,DC=domain,dc=com'
   #   bindPassword: 'TopSecretPassword'
   #   userDnTemplate: null

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -193,9 +193,8 @@ data:
 
 In order to enable LDAP authentication, please carry out the following steps:
 
-1. Set `image.tag` in your values to an image with LDAP support (e.g. `v3.0.11-ldap`)
-2. Configure the `remoteAuth` settings to enable the LDAP backend (see below)
-3. Make sure you set *all* of the `remoteAuth.ldap` settings shown in the `values.yaml` file
+1. Configure the `remoteAuth` settings to enable the LDAP backend (see below)
+2. Make sure you set *all* of the `remoteAuth.ldap` settings shown in the `values.yaml` file
 
 For example:
 
@@ -214,3 +213,19 @@ remoteAuth:
 
 Note: in order to use anonymous LDAP binding set `bindDn` and `bindPassword`
 to an empty string as in the example above.
+
+If you need to specify your own CA certificate, follow the instructions below.
+
+In your `values.yaml` file define your CA certificate content in `caCertData`:
+
+```yaml
+  ldap:
+    serverUri: 'ldap://domain.com'
+    startTls: true
+    ignoreCertErrors: false
+    caCertFile: /etc/netbox/config/ldap/ldap_ca.crt
+    caCertData: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+```

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -223,7 +223,6 @@ In your `values.yaml` file define your CA certificate content in `caCertData`:
     serverUri: 'ldap://domain.com'
     startTls: true
     ignoreCertErrors: false
-    caCertFile: /etc/netbox/config/ldap/ldap_ca.crt
     caCertData: |
       -----BEGIN CERTIFICATE-----
       ...


### PR DESCRIPTION
This PR support for custom CA certificates when using LDAP authentication. Users can now provide their own CA certificates in the caCertData value, which will be mounted as a file in the container. As this is my first contribution to this project, I am open to any feedback or suggestions for improvement. 

Closes #119
