### PR TITLE
Fix for affinity indentation

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.62
+version: 5.0.0-beta.64
 appVersion: "v4.0.8"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/worker-deployment.yaml
+++ b/charts/netbox/templates/worker-deployment.yaml
@@ -181,7 +181,7 @@ spec:
       nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.worker.nodeSelector "context" $) | nindent 6 }}
       {{- end }}
       {{- if .Values.worker.affinity }}
-      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.worker.affinity "context" $) | nindent 6 }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.worker.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.worker.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.worker.tolerations "context" .) | nindent 6 }}


### PR DESCRIPTION
At the moment podAffinity is created with wrong indentation. For example 

---
`extraVals.yml`

```yaml
worker:
  affinity:
    podAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchLabels:
            app.kubernetes.io/name: netbox
        topologyKey: kubernetes.io/hostname
```

```shell
helm template -s templates/worker-deployment.yaml netbox . -f extraVals.yml
.
.
REDACTED_FOR_KEEPING_FOCUS_ON_THE_PROBLEM
.
.
      - name: media
        persistentVolumeClaim:
          claimName: netbox-media
      affinity:
      podAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
        - labelSelector:
            matchLabels:
              app.kubernetes.io/name: netbox
          topologyKey: kubernetes.io/hostname
```

with the change it generates the template as it follows 

```shell
helm template -s templates/worker-deployment.yaml netbox . -f extraVals.yml
.
.
.
        persistentVolumeClaim:
          claimName: netbox-media
      affinity:
        podAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchLabels:
                app.kubernetes.io/name: netbox
            topologyKey: kubernetes.io/hostname
```