### PR TITLE
Fix caCertData to use root data object instead of current context

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.70
+version: 5.0.0-beta.72
 appVersion: "v4.0.8"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.72
+version: 5.0.0-beta.74
 appVersion: "v4.0.8"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -293,7 +293,7 @@ data:
     AUTH_LDAP_BIND_DN: {{ $.Values.remoteAuth.ldap.bindDn | quote }}
     AUTH_LDAP_START_TLS: {{ toJson $.Values.remoteAuth.ldap.startTls }}
     LDAP_IGNORE_CERT_ERRORS: {{ toJson $.Values.remoteAuth.ldap.ignoreCertErrors }}
-    {{- if .Values.remoteAuth.ldap.caCertData }}
+    {{- if $.Values.remoteAuth.ldap.caCertData }}
     LDAP_CA_CERT_FILE: /etc/netbox/config/ldap/ldap_ca.crt
     {{- end }}
     AUTH_LDAP_USER_DN_TEMPLATE: {{ default nil $.Values.remoteAuth.ldap.userDnTemplate }}
@@ -307,9 +307,9 @@ data:
     AUTH_LDAP_MIRROR_GROUPS: {{ toJson $.Values.remoteAuth.ldap.mirrorGroups }}
     AUTH_LDAP_MIRROR_GROUPS_EXCEPT: {{ toJson $.Values.remoteAuth.ldap.mirrorGroupsExcept }}
     AUTH_LDAP_CACHE_TIMEOUT: {{ int $.Values.remoteAuth.ldap.cacheTimeout }}
-  {{- if .Values.remoteAuth.ldap.caCertData }}
+  {{- if $.Values.remoteAuth.ldap.caCertData }}
   ldap_ca.crt: |-
-    {{- toYaml .Values.remoteAuth.ldap.caCertData | nindent 4 }}
+    {{- toYaml $.Values.remoteAuth.ldap.caCertData | nindent 4 }}
   {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -70,7 +70,7 @@ spec:
               mountPath: /etc/netbox/config/ldap/ldap_config.py
               subPath: ldap_config.py
               readOnly: true
-            {{- if .Values.remoteAuth.ldap.caCertData }}
+            {{- if $.Values.remoteAuth.ldap.caCertData }}
             - name: config
               mountPath: /etc/netbox/config/ldap/ldap_ca.crt
               subPath: ldap_ca.crt

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -160,7 +160,7 @@ spec:
           mountPath: /etc/netbox/config/ldap/ldap_config.py
           subPath: ldap_config.py
           readOnly: true
-        {{- if .Values.remoteAuth.ldap.caCertData }}
+        {{- if $.Values.remoteAuth.ldap.caCertData }}
         - name: config
           mountPath: /etc/netbox/config/ldap/ldap_ca.crt
           subPath: ldap_ca.crt

--- a/charts/netbox/templates/worker-deployment.yaml
+++ b/charts/netbox/templates/worker-deployment.yaml
@@ -76,7 +76,7 @@ spec:
           mountPath: /etc/netbox/config/ldap/ldap_config.py
           subPath: ldap_config.py
           readOnly: true
-        {{- if .Values.remoteAuth.ldap.caCertData }}
+        {{- if $.Values.remoteAuth.ldap.caCertData }}
         - name: config
           mountPath: /etc/netbox/config/ldap/ldap_ca.crt
           subPath: ldap_ca.crt


### PR DESCRIPTION
It looks like this didn't work out. It looks like the reference got wrong if there is a range. If we use `$` it access the root data object.

```
Helm install failed for release netbox/netbox with chart netbox@5.0.0-beta.71: template: netbox/templates/worker-deployment.yaml:28:28: executing "netbox/templates/worker-deployment.yaml" at <include (print $.Template.BasePath "/configmap.yaml") .>: error calling include: template: netbox/templates/configmap.yaml:296:18: executing "netbox/templates/configmap.yaml" at <.Values.remoteAuth.ldap.caCertData>: can't evaluate field Values in type interface {}
```

Ref #293 