### PR TITLE
Quoted ingressClassName causes chart to break

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.74
+version: 5.0.0-beta.75
 appVersion: "v4.0.8"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/ingress.yaml
+++ b/charts/netbox/templates/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.className | quote }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- with .Values.ingress.tls }}
   tls:
   {{- range . }}


### PR DESCRIPTION
- If you enable ingress it's gonna default to having a ingress.Classname: '' and that is not supported.

Resolves: #305