### PR TITLE
Fix indentation of ldap_ca.crt data

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.75
+version: 5.0.0-beta.76
 appVersion: "v4.0.8"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -309,7 +309,6 @@ data:
     AUTH_LDAP_CACHE_TIMEOUT: {{ int $.Values.remoteAuth.ldap.cacheTimeout }}
   {{- if $.Values.remoteAuth.ldap.caCertData }}
   ldap_ca.crt: {{- toYaml $.Values.remoteAuth.ldap.caCertData | indent 4 }}
-    {{- toYaml $.Values.remoteAuth.ldap.caCertData | indent 2 }}
   {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -308,7 +308,7 @@ data:
     AUTH_LDAP_MIRROR_GROUPS_EXCEPT: {{ toJson $.Values.remoteAuth.ldap.mirrorGroupsExcept }}
     AUTH_LDAP_CACHE_TIMEOUT: {{ int $.Values.remoteAuth.ldap.cacheTimeout }}
   {{- if $.Values.remoteAuth.ldap.caCertData }}
-  ldap_ca.crt: |-
+  ldap_ca.crt: {{- toYaml $.Values.remoteAuth.ldap.caCertData | indent 4 }}
     {{- toYaml $.Values.remoteAuth.ldap.caCertData | indent 2 }}
   {{- end }}
   {{- end }}

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -309,7 +309,7 @@ data:
     AUTH_LDAP_CACHE_TIMEOUT: {{ int $.Values.remoteAuth.ldap.cacheTimeout }}
   {{- if $.Values.remoteAuth.ldap.caCertData }}
   ldap_ca.crt: |-
-    {{- toYaml $.Values.remoteAuth.ldap.caCertData | nindent 4 }}
+    {{- toYaml $.Values.remoteAuth.ldap.caCertData | indent 2 }}
   {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
- It looks like a pipe symbol was added at the top of the ldap_ca.crt data file

I think that the `nindent` can cause this as it prepends a new line.

Cert data was defined like this:

```
        caCertData: |
          -----BEGIN CERTIFICATE-----
          ...
          -----END CERTIFICATE-----
```

Output in the ldap_ca.crt file:

```
  ldap_ca.crt: |-
  |
    -----BEGIN CERTIFICATE-----
```