### PR TITLE
Correct redis version used in 5.x release in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ Type: `kubernetes.io/basic-auth`
   * NAPALM support has been moved into a plugin since NetBox 3.5, so all NAPALM configuration has been **removed from this chart**.
   * Please consult the [NetBox](https://docs.netbox.dev/en/stable/release-notes/) and [netbox-docker](https://github.com/netbox-community/netbox-docker) release notes in case there are any other changes that may affect your configuration.
 * The Bitnami [PostgreSQL](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) sub-chart was upgraded from 10.x to 15.x; please read the upstream upgrade notes if you are using the bundled PostgreSQL.
-* The Bitnami [Redis](https://github.com/bitnami/charts/tree/main/bitnami/redis) sub-chart was upgraded from 15.x to 19.x; please read the upstream upgrade notes if you are using the bundled Redis.
+* The Bitnami [Redis](https://github.com/bitnami/charts/tree/main/bitnami/redis) sub-chart was upgraded from 15.x to 20.x; please read the upstream upgrade notes if you are using the bundled Redis.
 
 ### From 3.x to 4.x
 

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.82
+version: 5.0.0-beta.83
 appVersion: "v4.0.9"
 type: application
 kubeVersion: ^1.25.0-0


### PR DESCRIPTION
With https://github.com/netbox-community/netbox-chart/pull/301 the Redis helm chart got updated to 20.x.x, but the README still mentions version 19.x.x.