### PR TITLE
Split Python files from ConfigMap

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,8 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.py]
+indent_size = 4
+
 [*.md]
 trim_trailing_whitespace = false

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203, W503
+per-file-ignores =
+  charts/netbox/files/*:E131,E251,E266,E302,E305,E501,E722,F821

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,4 +30,11 @@ jobs:
           DEFAULT_BRANCH: develop
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_JSCPD: false
+          VALIDATE_PYTHON_MYPY: false
+          VALIDATE_PYTHON_PYINK: false
           FILTER_REGEX_EXCLUDE: charts/\w+/templates/.*\.yaml
+          LINTER_RULES_PATH: /
+          PYTHON_BLACK_CONFIG_FILE: pyproject.toml
+          PYTHON_PYLINT_CONFIG_FILE: pyproject.toml
+          PYTHON_ISORT_CONFIG_FILE: pyproject.toml
+          PYTHON_RUFF_CONFIG_FILE: pyproject.toml

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.89
+version: 5.0.0-beta.90
 appVersion: "v4.1.0"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/files/configuration.py
+++ b/charts/netbox/files/configuration.py
@@ -1,0 +1,70 @@
+###################################################################
+#  This file serves as a base configuration for Netbox            #
+#  https://netboxlabs.com/docs/netbox/en/stable/configuration/    #
+###################################################################
+
+import re
+from pathlib import Path
+
+import yaml
+import os
+
+def _deep_merge(source, destination):
+    """Inspired by https://stackoverflow.com/a/20666342"""
+    for key, value in source.items():
+        dst_value = destination.get(key)
+
+        if isinstance(value, dict) and isinstance(dst_value, dict):
+            _deep_merge(value, dst_value)
+        else:
+            destination[key] = value
+
+    return destination
+
+def _load_yaml():
+    """Load YAML from files"""
+    extraConfigBase = Path("/run/config/extra")
+    configFiles = [Path("/run/config/netbox/netbox.yaml")]
+
+    configFiles.extend(sorted(extraConfigBase.glob("*/*.yaml")))
+
+    for configFile in configFiles:
+        with open(configFile, 'r', encoding='utf-8') as f:
+            config = yaml.safe_load(f)
+        _deep_merge(config, globals())
+
+def _read_secret(secret_name: str, secret_key: str, default: str | None = None) -> str | None:
+    """Read secret from file"""
+    try:
+        f = open(
+          "/run/secrets/{name}/{key}".format(name=secret_name, key=secret_key),
+          'r',
+          encoding='utf-8'
+        )
+    except EnvironmentError:
+        return default
+    else:
+        with f:
+            return f.readline().strip()
+
+CORS_ORIGIN_REGEX_WHITELIST = list()
+DATABASE = dict()
+EMAIL = dict()
+REDIS = dict()
+
+_load_yaml()
+
+DATABASE["PASSWORD"] = _read_secret("netbox", "db_password")
+EMAIL["PASSWORD"] = _read_secret("netbox", "email_password")
+REDIS["tasks"]["PASSWORD"] = _read_secret("netbox", "redis_tasks_password")
+REDIS["caching"]["PASSWORD"] = _read_secret("netbox", "redis_cache_password")
+SECRET_KEY = _read_secret("netbox", "secret_key")
+
+# Post-process certain values
+CORS_ORIGIN_REGEX_WHITELIST = [re.compile(r) for r in CORS_ORIGIN_REGEX_WHITELIST]
+if REDIS['tasks']['SENTINELS']:
+  REDIS['tasks']['SENTINELS'] = [tuple(x.split(r":")) for x in REDIS['tasks']['SENTINELS']]
+if REDIS['caching']['SENTINELS']:
+  REDIS['caching']['SENTINELS'] = [tuple(x.split(r":")) for x in REDIS['caching']['SENTINELS']]
+if ALLOWED_HOSTS_INCLUDES_POD_ID:
+  ALLOWED_HOSTS.append(os.getenv("POD_IP"))

--- a/charts/netbox/files/configuration.py
+++ b/charts/netbox/files/configuration.py
@@ -1,13 +1,14 @@
-###################################################################
-#  This file serves as a base configuration for Netbox            #
-#  https://netboxlabs.com/docs/netbox/en/stable/configuration/    #
-###################################################################
+"""
+This file serves as a base configuration for Netbox
+https://netboxlabs.com/docs/netbox/en/stable/configuration/
+"""
 
+import os
 import re
 from pathlib import Path
 
 import yaml
-import os
+
 
 def _deep_merge(source, destination):
     """Inspired by https://stackoverflow.com/a/20666342"""
@@ -21,36 +22,38 @@ def _deep_merge(source, destination):
 
     return destination
 
-def _load_yaml():
+
+def _load_yaml() -> None:
     """Load YAML from files"""
-    extraConfigBase = Path("/run/config/extra")
-    configFiles = [Path("/run/config/netbox/netbox.yaml")]
+    extra_config_base = Path("/run/config/extra")
+    config_files = [Path("/run/config/netbox/netbox.yaml")]
 
-    configFiles.extend(sorted(extraConfigBase.glob("*/*.yaml")))
+    config_files.extend(sorted(extra_config_base.glob("*/*.yaml")))
 
-    for configFile in configFiles:
-        with open(configFile, 'r', encoding='utf-8') as f:
+    for config_file in config_files:
+        with open(config_file, "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
         _deep_merge(config, globals())
+
 
 def _read_secret(secret_name: str, secret_key: str, default: str | None = None) -> str | None:
     """Read secret from file"""
     try:
         f = open(
-          "/run/secrets/{name}/{key}".format(name=secret_name, key=secret_key),
-          'r',
-          encoding='utf-8'
+            f"/run/secrets/{secret_name}/{secret_key}",
+            "r",
+            encoding="utf-8",
         )
     except EnvironmentError:
         return default
-    else:
-        with f:
-            return f.readline().strip()
+    with f:
+        return f.readline().strip()
 
-CORS_ORIGIN_REGEX_WHITELIST = list()
-DATABASE = dict()
-EMAIL = dict()
-REDIS = dict()
+
+CORS_ORIGIN_REGEX_WHITELIST = []
+DATABASE = {}
+EMAIL = {}
+REDIS = {}
 
 _load_yaml()
 
@@ -62,9 +65,9 @@ SECRET_KEY = _read_secret("netbox", "secret_key")
 
 # Post-process certain values
 CORS_ORIGIN_REGEX_WHITELIST = [re.compile(r) for r in CORS_ORIGIN_REGEX_WHITELIST]
-if REDIS['tasks']['SENTINELS']:
-  REDIS['tasks']['SENTINELS'] = [tuple(x.split(r":")) for x in REDIS['tasks']['SENTINELS']]
-if REDIS['caching']['SENTINELS']:
-  REDIS['caching']['SENTINELS'] = [tuple(x.split(r":")) for x in REDIS['caching']['SENTINELS']]
+if "SENTINELS" in REDIS["tasks"]:
+    REDIS["tasks"]["SENTINELS"] = [tuple(x.split(r":")) for x in REDIS["tasks"]["SENTINELS"]]
+if "SENTINELS" in REDIS["caching"]:
+    REDIS["caching"]["SENTINELS"] = [tuple(x.split(r":")) for x in REDIS["caching"]["SENTINELS"]]
 if ALLOWED_HOSTS_INCLUDES_POD_ID:
-  ALLOWED_HOSTS.append(os.getenv("POD_IP"))
+    ALLOWED_HOSTS.append(os.getenv("POD_IP"))

--- a/charts/netbox/files/ldap_config.py
+++ b/charts/netbox/files/ldap_config.py
@@ -1,0 +1,73 @@
+###################################################################
+#  This file serves as a LDAP configuration for Netbox            #
+#  https://netboxlabs.com/docs/netbox/en/stable/configuration/    #
+###################################################################
+
+from functools import reduce
+from importlib import import_module
+from django_auth_ldap.config import LDAPSearch, LDAPGroupQuery
+
+import yaml
+import ldap
+
+def _load_yaml():
+    """Load YAML from file"""
+    with open("/run/config/netbox/ldap.yaml", 'r', encoding='utf-8') as f:
+        config = yaml.safe_load(f)
+    globals().update(config)
+
+def _read_secret(secret_name: str, secret_key: str, default: str | None = None) -> str | None:
+    """Read secret from file"""
+    try:
+        f = open(
+          "/run/secrets/{name}/{key}".format(name=secret_name, key=secret_key),
+          'r',
+          encoding='utf-8'
+        )
+    except EnvironmentError:
+        return default
+    else:
+        with f:
+            return f.readline().strip()
+
+# Import and return the group type based on string name
+def _import_group_type(group_type_name):
+    mod = import_module("django_auth_ldap.config")
+    try:
+        return getattr(mod, group_type_name)()
+    except AttributeError:
+        return None
+
+_load_yaml()
+
+# The following may be needed if you are binding to Active Directory.
+AUTH_LDAP_CONNECTION_OPTIONS = {
+    ldap.OPT_REFERRALS: 0
+}
+
+# Set the DN and password for the NetBox service account if needed.
+AUTH_LDAP_BIND_PASSWORD = _read_secret("netbox", "ldap_bind_password")
+
+# This search ought to return all groups to which the user belongs. django_auth_ldap uses this to determine group
+# heirarchy.
+AUTH_LDAP_USER_SEARCH = LDAPSearch(
+    AUTH_LDAP_USER_SEARCH_BASEDN,
+    ldap.SCOPE_SUBTREE,
+    "(" + AUTH_LDAP_USER_SEARCH_ATTR + "=%(user)s)",
+)
+AUTH_LDAP_GROUP_SEARCH = LDAPSearch(
+    AUTH_LDAP_GROUP_SEARCH_BASEDN,
+    ldap.SCOPE_SUBTREE,
+    "(objectClass=" + AUTH_LDAP_GROUP_SEARCH_CLASS + ")",
+)
+AUTH_LDAP_GROUP_TYPE = _import_group_type(AUTH_LDAP_GROUP_TYPE)
+
+# Define a group required to login.
+AUTH_LDAP_REQUIRE_GROUP = reduce(lambda x, y: x | LDAPGroupQuery(y), AUTH_LDAP_REQUIRE_GROUP_LIST, False)
+
+# Define special user types using groups. Exercise great caution when assigning superuser status.
+AUTH_LDAP_USER_FLAGS_BY_GROUP = {
+    "is_active": reduce(lambda x, y: x | LDAPGroupQuery(y), AUTH_LDAP_REQUIRE_GROUP_LIST, False),
+    "is_staff": reduce(lambda x, y: x | LDAPGroupQuery(y), AUTH_LDAP_IS_ADMIN_LIST, False),
+    "is_superuser": reduce(lambda x, y: x | LDAPGroupQuery(y), AUTH_LDAP_IS_SUPERUSER_LIST, False),
+}

--- a/charts/netbox/files/ldap_config.py
+++ b/charts/netbox/files/ldap_config.py
@@ -1,54 +1,57 @@
-###################################################################
-#  This file serves as a LDAP configuration for Netbox            #
-#  https://netboxlabs.com/docs/netbox/en/stable/configuration/    #
-###################################################################
+"""
+This file serves as a LDAP configuration for Netbox
+https://netboxlabs.com/docs/netbox/en/stable/configuration/
+"""
 
 from functools import reduce
 from importlib import import_module
-from django_auth_ldap.config import LDAPSearch, LDAPGroupQuery
+from typing import Any
 
-import yaml
 import ldap
+import yaml
+from django_auth_ldap.config import LDAPGroupQuery, LDAPSearch
 
-def _load_yaml():
+
+def _load_yaml() -> None:
     """Load YAML from file"""
-    with open("/run/config/netbox/ldap.yaml", 'r', encoding='utf-8') as f:
+    with open("/run/config/netbox/ldap.yaml", "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
     globals().update(config)
+
 
 def _read_secret(secret_name: str, secret_key: str, default: str | None = None) -> str | None:
     """Read secret from file"""
     try:
         f = open(
-          "/run/secrets/{name}/{key}".format(name=secret_name, key=secret_key),
-          'r',
-          encoding='utf-8'
+            f"/run/secrets/{secret_name}/{secret_key}",
+            "r",
+            encoding="utf-8",
         )
     except EnvironmentError:
         return default
-    else:
-        with f:
-            return f.readline().strip()
+    with f:
+        return f.readline().strip()
 
-# Import and return the group type based on string name
-def _import_group_type(group_type_name):
+
+def _import_group_type(group_type_name: str) -> Any | None:
+    """Import and return the group type based on name"""
     mod = import_module("django_auth_ldap.config")
     try:
         return getattr(mod, group_type_name)()
     except AttributeError:
         return None
 
+
 _load_yaml()
 
 # The following may be needed if you are binding to Active Directory.
-AUTH_LDAP_CONNECTION_OPTIONS = {
-    ldap.OPT_REFERRALS: 0
-}
+AUTH_LDAP_CONNECTION_OPTIONS = {ldap.OPT_REFERRALS: 0}
 
 # Set the DN and password for the NetBox service account if needed.
 AUTH_LDAP_BIND_PASSWORD = _read_secret("netbox", "ldap_bind_password")
 
-# This search ought to return all groups to which the user belongs. django_auth_ldap uses this to determine group
+# This search ought to return all groups to which the user belongs.
+# django_auth_ldap uses this to determine group
 # heirarchy.
 AUTH_LDAP_USER_SEARCH = LDAPSearch(
     AUTH_LDAP_USER_SEARCH_BASEDN,
@@ -63,7 +66,9 @@ AUTH_LDAP_GROUP_SEARCH = LDAPSearch(
 AUTH_LDAP_GROUP_TYPE = _import_group_type(AUTH_LDAP_GROUP_TYPE)
 
 # Define a group required to login.
-AUTH_LDAP_REQUIRE_GROUP = reduce(lambda x, y: x | LDAPGroupQuery(y), AUTH_LDAP_REQUIRE_GROUP_LIST, False)
+AUTH_LDAP_REQUIRE_GROUP = reduce(
+    lambda x, y: x | LDAPGroupQuery(y), AUTH_LDAP_REQUIRE_GROUP_LIST, False
+)
 
 # Define special user types using groups. Exercise great caution when assigning superuser status.
 AUTH_LDAP_USER_FLAGS_BY_GROUP = {

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -9,73 +9,11 @@ metadata:
   {{- end }}
 data:
   configuration.py: |-
-    import re
-    from pathlib import Path
-
-    import yaml
-    import os
-
-
-    def _deep_merge(source, destination):
-        """Inspired by https://stackoverflow.com/a/20666342"""
-        for key, value in source.items():
-            dst_value = destination.get(key)
-
-            if isinstance(value, dict) and isinstance(dst_value, dict):
-                _deep_merge(value, dst_value)
-            else:
-                destination[key] = value
-
-        return destination
-
-
-    def _load_yaml():
-        extraConfigBase = Path("/run/config/extra")
-        configFiles = [Path("/run/config/netbox/netbox.yaml")]
-
-        configFiles.extend(sorted(extraConfigBase.glob("*/*.yaml")))
-
-        for configFile in configFiles:
-            with open(configFile, "r") as f:
-                config = yaml.safe_load(f)
-
-            _deep_merge(config, globals())
-
-
-    def _load_secret(name, key):
-        path = "/run/secrets/{name}/{key}".format(name=name, key=key)
-        with open(path, "r") as f:
-            return f.read()
-
-
-    CORS_ORIGIN_REGEX_WHITELIST = list()
-    DATABASE = dict()
-    EMAIL = dict()
-    REDIS = dict()
-
-    _load_yaml()
-
-    DATABASE["PASSWORD"] = _load_secret("netbox", "db_password")
-    EMAIL["PASSWORD"] = _load_secret("netbox", "email_password")
-    REDIS["tasks"]["PASSWORD"] = _load_secret("netbox", "redis_tasks_password")
-    REDIS["caching"]["PASSWORD"] = _load_secret("netbox", "redis_cache_password")
-    SECRET_KEY = _load_secret("netbox", "secret_key")
-
-    # Post-process certain values
-    CORS_ORIGIN_REGEX_WHITELIST = [re.compile(r) for r in CORS_ORIGIN_REGEX_WHITELIST]
-    {{- if and (not .Values.redis.enabled) .Values.tasksRedis.sentinels }}
-    REDIS['tasks']['SENTINELS'] = [tuple(x.split(r":")) for x in REDIS['tasks']['SENTINELS']]
-    {{- end }}
-    {{- if and (not .Values.redis.enabled) .Values.cachingRedis.sentinels }}
-    REDIS['caching']['SENTINELS'] = [tuple(x.split(r":")) for x in REDIS['caching']['SENTINELS']]
-    {{- end }}
-
-    {{- if .Values.allowedHostsIncludesPodIP }}
-    ALLOWED_HOSTS.append(os.getenv("POD_IP"))
-    {{- end }}
+    {{ .Files.Get "files/configuration.py" | nindent 4 }}
 
   netbox.yaml: |-
     ALLOWED_HOSTS: {{ toJson .Values.allowedHosts }}
+    ALLOWED_HOSTS_INCLUDES_POD_ID: {{ .Values.allowedHostsIncludesPodIP }}
 
     DATABASE:
       {{ if .Values.postgresql.enabled -}}
@@ -186,7 +124,7 @@ data:
         SENTINEL_TIMEOUT: {{ .Values.tasksRedis.sentinelTimeout | int }}
         {{- else }}
         HOST: {{ .Values.tasksRedis.host | quote }}
-        PORT: {{ .Values.tasksRedis.port | int}}
+        PORT: {{ .Values.tasksRedis.port | int }}
         {{- end }}
         USERNAME: {{ .Values.tasksRedis.username | quote }}
         DATABASE: {{ int .Values.tasksRedis.database }}
@@ -229,85 +167,7 @@ data:
   {{- if eq . "netbox.authentication.LDAPBackend" }}
 
   ldap_config.py: |-
-    from importlib import import_module
-
-    from django_auth_ldap.config import LDAPSearch, LDAPGroupQuery
-
-    import ldap
-
-    import yaml
-
-
-    def _load_yaml():
-        with open("/run/config/netbox/ldap.yaml", "r") as f:
-            config = yaml.safe_load(f)
-        globals().update(config)
-
-
-    def _load_secret(name, key):
-        path = "/run/secrets/{name}/{key}".format(name=name, key=key)
-        with open(path, "r") as f:
-            return f.read()
-
-
-    # Import and return the group type based on string name
-    def _import_group_type(group_type_name):
-        mod = import_module("django_auth_ldap.config")
-        try:
-            return getattr(mod, group_type_name)()
-        except AttributeError:
-            return None
-
-
-    _load_yaml()
-
-    AUTH_LDAP_BIND_PASSWORD = _load_secret("netbox", "ldap_bind_password")
-    # The following may be needed if you are binding to Active Directory.
-    AUTH_LDAP_CONNECTION_OPTIONS = {ldap.OPT_REFERRALS: 0}
-    AUTH_LDAP_USER_SEARCH = LDAPSearch(
-        AUTH_LDAP_USER_SEARCH_BASEDN,
-        ldap.SCOPE_SUBTREE,
-        "(" + AUTH_LDAP_USER_SEARCH_ATTR + "=%(user)s)",
-    )
-    AUTH_LDAP_GROUP_SEARCH = LDAPSearch(
-        AUTH_LDAP_GROUP_SEARCH_BASEDN,
-        ldap.SCOPE_SUBTREE,
-        "(objectClass=" + AUTH_LDAP_GROUP_SEARCH_CLASS + ")",
-    )
-    AUTH_LDAP_GROUP_TYPE = _import_group_type(AUTH_LDAP_GROUP_TYPE)
-
-    # Required groups to be able to login to Netbox
-    AUTH_LDAP_REQUIRE_GROUP = (
-        {{- range $index, $group := $.Values.remoteAuth.ldap.requireGroupDn }}
-        LDAPGroupQuery({{ $group | quote }}){{ if ne (add $index 1) (len $.Values.remoteAuth.ldap.requireGroupDn) }} | {{ end }}
-        {{- end }}
-    )
-
-    # Define special user types using groups. Exercise great caution when assigning superuser status.
-    AUTH_LDAP_USER_FLAGS_BY_GROUP = {
-        "is_active": (
-            {{- range $index, $group := $.Values.remoteAuth.ldap.requireGroupDn }}
-            LDAPGroupQuery({{ $group | quote }}){{ if ne (add $index 1) (len $.Values.remoteAuth.ldap.requireGroupDn) }} | {{ end }}
-            {{- end }}
-        ),
-        "is_staff": (
-            {{- range $index, $group := $.Values.remoteAuth.ldap.isAdminDn }}
-            LDAPGroupQuery({{ $group | quote }}){{ if ne (add $index 1) (len $.Values.remoteAuth.ldap.isAdminDn) }} | {{ end }}
-            {{- end }}
-        ),
-        "is_superuser": (
-            {{- range $index, $group := $.Values.remoteAuth.ldap.isSuperUserDn }}
-            LDAPGroupQuery({{ $group | quote }}){{ if ne (add $index 1) (len $.Values.remoteAuth.ldap.isSuperUserDn) }} | {{ end }}
-            {{- end }}
-        ),
-    }
-
-    # Populate the Django user from the LDAP directory.
-    AUTH_LDAP_USER_ATTR_MAP = {
-        "first_name": {{ $.Values.remoteAuth.ldap.attrFirstName | quote }},
-        "last_name": {{ $.Values.remoteAuth.ldap.attrLastName | quote }},
-        "email": {{ $.Values.remoteAuth.ldap.attrMail | quote }},
-    }
+    {{ .Files.Get "files/ldap_config.py" | nindent 4 }}
 
   ldap.yaml: |-
     AUTH_LDAP_SERVER_URI: {{ $.Values.remoteAuth.ldap.serverUri | quote }}
@@ -327,6 +187,16 @@ data:
     AUTH_LDAP_MIRROR_GROUPS: {{ toJson $.Values.remoteAuth.ldap.mirrorGroups }}
     AUTH_LDAP_MIRROR_GROUPS_EXCEPT: {{ toJson $.Values.remoteAuth.ldap.mirrorGroupsExcept }}
     AUTH_LDAP_CACHE_TIMEOUT: {{ int $.Values.remoteAuth.ldap.cacheTimeout }}
+
+    AUTH_LDAP_REQUIRE_GROUP_LIST: {{ toJson $.Values.remoteAuth.ldap.requireGroupDn }}
+    AUTH_LDAP_IS_ADMIN_LIST: {{ toJson $.Values.remoteAuth.ldap.isAdminDn }}
+    AUTH_LDAP_IS_SUPERUSER_LIST: {{ toJson $.Values.remoteAuth.ldap.isSuperUserDn }}
+
+    # Populate the Django user from the LDAP directory.
+    AUTH_LDAP_USER_ATTR_MAP:
+      first_name: {{ $.Values.remoteAuth.ldap.attrFirstName | quote }}
+      last_name: {{ $.Values.remoteAuth.ldap.attrLastName | quote }}
+      email: {{ $.Values.remoteAuth.ldap.attrMail | quote }}
 
   {{- if $.Values.remoteAuth.ldap.caCertData }}
   ldap_ca.crt: {{- toYaml $.Values.remoteAuth.ldap.caCertData | indent 4 }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[tool.black]
+line_length = 100
+target-version = ['py38']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.git
+    | \.venv
+    | \.netbox
+    | \.vscode
+    | configuration
+  )/
+)
+'''
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+line_length = 100
+
+[tool.pylint.main]
+disable = ["duplicate-code", "import-error", "used-before-assignment", "undefined-variable"]
+
+[tool.pylint.format]
+max-line-length = "100"
+
+[tool.ruff.lint]
+ignore = ["F821"]


### PR DESCRIPTION
The purpose of this PR is to isolate Python files used in the Helm chart to apply usual tests and checks on them.
This should help to maintain these scripts:
* Automatic lint/format/assertions based on Netbox org config (#326).
* Better dev environment with Python-related IDE extensions and integrations.
* Possibility to add integration tests, which could help to assess contributions like #318.
* Same features from Helm chart point of view.

From a more opinionated PoV, I believe keeping Python files away from Helm chart templating would ensure more stable scripts and less breaking changes there.
