### PR TITLE
[v6] Switch from Redis to Valkey

### DIFF
--- a/charts/netbox/Chart.lock
+++ b/charts/netbox/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.31.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.6.6
-- name: redis
+  version: 16.6.7
+- name: valkey
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.13.4
-digest: sha256:7e6379696176ded79bde536924f23c528aafecdc122b6e393416e7900d9f0b1c
-generated: "2025-05-05T11:32:48.136824282Z"
+  version: 3.0.4
+digest: sha256:4a30cc9ebacbfed97a400c69e3a9d265f981d37bc44ade99217ce319db5e5059
+generated: "2025-05-06T18:07:45.533219632Z"

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -26,10 +26,10 @@ dependencies:
     version: ^16.6.6
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
-  - name: redis
-    version: ^20.13.4
+  - name: valkey
+    version: ^3.0.4
     repository: oci://registry-1.docker.io/bitnamicharts
-    condition: redis.enabled
+    condition: valkey.enabled
 annotations:
   artifacthub.io/images: |
     - name: netbox

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -214,32 +214,32 @@ The following table lists the configurable parameters for this chart and their d
 | `externalDatabase.options`                      | Additional PostgreSQL client parameters                             | `{}`                                            |
 | `valkey.enabled`                                | Deploy Valkey using bundled Bitnami Valkey chart                    | `true`                                       |
 | `valkey.*`                                      | Values under this key are passed to the bundled Valkey chart        | n/a                                          |
-| `tasksRedis.database`                           | KV database number used for NetBox task queue                       | `0`                                          |
-| `tasksRedis.ssl`                                | Enable SSL when connecting to KV                                    | `false`                                      |
-| `tasksRedis.insecureSkipTlsVerify`              | Skip TLS certificate verification when connecting to KV             | `false`                                      |
-| `tasksRedis.caCertPath`                         | Path to CA certificates bundle for KV (needs mounting manually)     | `""`                                         |
-| `tasksRedis.host`                               | KV host to use when `valkey.enabled` is `false`                     | `"netbox-redis"`                             |
-| `tasksRedis.port`                               | Port number for external KV                                         | `6379`                                       |
-| `tasksRedis.sentinels`                          | List of sentinels in `host:port` form (`host` and `port` not used)  | `[]`                                         |
-| `tasksRedis.sentinelService`                    | Sentinel master service name                                        | `"netbox-redis"`                             |
-| `tasksRedis.sentinelTimeout`                    | Sentinel connection timeout, in seconds                             | `300` (5 minutes)                            |
-| `tasksRedis.username`                           | Username for external KV                                            | `""`                                         |
-| `tasksRedis.password`                           | Password for external KV (see also `existingSecret`)                | `""`                                         |
-| `tasksRedis.existingSecretName`                 | Fetch password for external KV from a different `Secret`            | `""`                                         |
-| `tasksRedis.existingSecretKey`                  | Key to fetch the password in the above `Secret`                     | `tasks-password`                             |
-| `cachingRedis.database`                         | KV database number used for caching views                           | `1`                                          |
-| `cachingRedis.ssl`                              | Enable SSL when connecting to KV                                    | `false`                                      |
-| `cachingRedis.insecureSkipTlsVerify`            | Skip TLS certificate verification when connecting to KV             | `false`                                      |
-| `cachingRedis.caCertPath`                       | Path to CA certificates bundle for KV (needs mounting manually)     | `""`                                         |
-| `cachingRedis.host`                             | KV host to use when `valkey.enabled` is `false`                     | `"netbox-redis"`                             |
-| `cachingRedis.port`                             | Port number for external KV                                         | `6379`                                       |
-| `cachingRedis.sentinels`                        | List of sentinels in `host:port` form (`host` and `port` not used)  | `[]`                                         |
-| `cachingRedis.sentinelService`                  | Sentinel master service name                                        | `"netbox-redis"`                             |
-| `cachingRedis.sentinelTimeout`                  | Sentinel connection timeout, in seconds                             | `300` (5 minutes)                            |
-| `cachingRedis.username`                         | Username for external KV                                            | `""`                                         |
-| `cachingRedis.password`                         | Password for external KV (see also `existingSecret`)                | `""`                                         |
-| `cachingRedis.existingSecretName`               | Fetch password for external KV from a different `Secret`            | `""`                                         |
-| `cachingRedis.existingSecretKey`                | Key to fetch the password in the above `Secret`                     | `cache-password`                             |
+| `tasksDatabase.database`                           | KV database number used for NetBox task queue                       | `0`                                          |
+| `tasksDatabase.ssl`                                | Enable SSL when connecting to KV                                    | `false`                                      |
+| `tasksDatabase.insecureSkipTlsVerify`              | Skip TLS certificate verification when connecting to KV             | `false`                                      |
+| `tasksDatabase.caCertPath`                         | Path to CA certificates bundle for KV (needs mounting manually)     | `""`                                         |
+| `tasksDatabase.host`                               | KV host to use when `valkey.enabled` is `false`                     | `"netbox-kv"`                             |
+| `tasksDatabase.port`                               | Port number for external KV                                         | `6379`                                       |
+| `tasksDatabase.sentinels`                          | List of sentinels in `host:port` form (`host` and `port` not used)  | `[]`                                         |
+| `tasksDatabase.sentinelService`                    | Sentinel master service name                                        | `"netbox-kv"`                             |
+| `tasksDatabase.sentinelTimeout`                    | Sentinel connection timeout, in seconds                             | `300` (5 minutes)                            |
+| `tasksDatabase.username`                           | Username for external KV                                            | `""`                                         |
+| `tasksDatabase.password`                           | Password for external KV (see also `existingSecret`)                | `""`                                         |
+| `tasksDatabase.existingSecretName`                 | Fetch password for external KV from a different `Secret`            | `""`                                         |
+| `tasksDatabase.existingSecretKey`                  | Key to fetch the password in the above `Secret`                     | `tasks-password`                             |
+| `cachingDatabase.database`                         | KV database number used for caching views                           | `1`                                          |
+| `cachingDatabase.ssl`                              | Enable SSL when connecting to KV                                    | `false`                                      |
+| `cachingDatabase.insecureSkipTlsVerify`            | Skip TLS certificate verification when connecting to KV             | `false`                                      |
+| `cachingDatabase.caCertPath`                       | Path to CA certificates bundle for KV (needs mounting manually)     | `""`                                         |
+| `cachingDatabase.host`                             | KV host to use when `valkey.enabled` is `false`                     | `"netbox-kv"`                             |
+| `cachingDatabase.port`                             | Port number for external KV                                         | `6379`                                       |
+| `cachingDatabase.sentinels`                        | List of sentinels in `host:port` form (`host` and `port` not used)  | `[]`                                         |
+| `cachingDatabase.sentinelService`                  | Sentinel master service name                                        | `"netbox-kv"`                             |
+| `cachingDatabase.sentinelTimeout`                  | Sentinel connection timeout, in seconds                             | `300` (5 minutes)                            |
+| `cachingDatabase.username`                         | Username for external KV                                            | `""`                                         |
+| `cachingDatabase.password`                         | Password for external KV (see also `existingSecret`)                | `""`                                         |
+| `cachingDatabase.existingSecretName`               | Fetch password for external KV from a different `Secret`            | `""`                                         |
+| `cachingDatabase.existingSecretKey`                | Key to fetch the password in the above `Secret`                     | `cache-password`                             |
 | `imagePullSecrets`                              | List of `Secret` names containing private registry credentials      | `[]`                                         |
 | `nameOverride`                                  | Override the application name (`netbox`) used throughout the chart  | `""`                                         |
 | `fullnameOverride`                              | Override the full name of resources created as part of the release  | `""`                                         |
@@ -471,13 +471,13 @@ Type: `kubernetes.io/basic-auth`
 | --------------------- | ------------------------------------------------- | ---------------------------------- |
 | `postgresql-password` | The password for the external PostgreSQL database | If `postgresql.enabled` is `false` |
 
-### Tasks secrets (`tasksRedis.existingSecretName`)
+### Tasks secrets (`tasksDatabase.existingSecretName`)
 
 | Key              | Description                                                   | Required?                     |
 | ---------------- | ------------------------------------------------------------- | ----------------------------- |
 | `tasks-password` | Password for the external KV database (tasks and/or cache)    | If `valkey.enabled` is `false` |
 
-### Cache secrets (`cachingRedis.existingSecretName`)
+### Cache secrets (`cachingDatabase.existingSecretName`)
 
 | Key              | Description                                                   | Required?                     |
 | ---------------- | ------------------------------------------------------------- | ----------------------------- |

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -27,7 +27,7 @@ helm install my-release oci://ghcr.io/netbox-community/netbox-chart/netbox
 
 ### Production Usage
 
-We recommend using separate external PostgreSQL and Redis instances. This
+We recommend using separate external PostgreSQL and Key-Value instances. This
 de-couples those services from the chart's bundled versions which may have
 complex upgrade requirements. A clustered PostgreSQL server (e.g. using Zalando's
 [Postgres Operator](https://github.com/zalando/postgres-operator)) and Redis
@@ -211,35 +211,35 @@ The following table lists the configurable parameters for this chart and their d
 | `externalDatabase.existingSecretKey`            | Key to fetch the password in the above `Secret`                     | `postgresql-password`                        |
 | `externalDatabase.connMaxAge`                   | The lifetime of a database connection, as an integer of seconds     | `300`                                        |
 | `externalDatabase.disableServerSideCursors`     | Disable the use of server-side cursors transaction pooling          | `false`                                      |
-| `externalDatabase.options`                      | Additional PostgreSQL client parameters             | `{}`                                            |
-| `redis.enabled`                                 | Deploy Redis using bundled Bitnami Redis chart                      | `true`                                       |
-| `redis.*`                                       | Values under this key are passed to the bundled Redis chart         | n/a                                          |
-| `tasksRedis.database`                           | Redis database number used for NetBox task queue                    | `0`                                          |
-| `tasksRedis.ssl`                                | Enable SSL when connecting to Redis                                 | `false`                                      |
-| `tasksRedis.insecureSkipTlsVerify`              | Skip TLS certificate verification when connecting to Redis          | `false`                                      |
-| `tasksRedis.caCertPath`                         | Path to CA certificates bundle for Redis (needs mounting manually)  | `""`                                         |
-| `tasksRedis.host`                               | Redis host to use when `redis.enabled` is `false`                   | `"netbox-redis"`                             |
-| `tasksRedis.port`                               | Port number for external Redis                                      | `6379`                                       |
+| `externalDatabase.options`                      | Additional PostgreSQL client parameters                             | `{}`                                            |
+| `valkey.enabled`                                | Deploy Valkey using bundled Bitnami Valkey chart                    | `true`                                       |
+| `valkey.*`                                      | Values under this key are passed to the bundled Valkey chart        | n/a                                          |
+| `tasksRedis.database`                           | KV database number used for NetBox task queue                       | `0`                                          |
+| `tasksRedis.ssl`                                | Enable SSL when connecting to KV                                    | `false`                                      |
+| `tasksRedis.insecureSkipTlsVerify`              | Skip TLS certificate verification when connecting to KV             | `false`                                      |
+| `tasksRedis.caCertPath`                         | Path to CA certificates bundle for KV (needs mounting manually)     | `""`                                         |
+| `tasksRedis.host`                               | KV host to use when `valkey.enabled` is `false`                     | `"netbox-redis"`                             |
+| `tasksRedis.port`                               | Port number for external KV                                         | `6379`                                       |
 | `tasksRedis.sentinels`                          | List of sentinels in `host:port` form (`host` and `port` not used)  | `[]`                                         |
 | `tasksRedis.sentinelService`                    | Sentinel master service name                                        | `"netbox-redis"`                             |
 | `tasksRedis.sentinelTimeout`                    | Sentinel connection timeout, in seconds                             | `300` (5 minutes)                            |
-| `tasksRedis.username`                           | Username for external Redis                                         | `""`                                         |
-| `tasksRedis.password`                           | Password for external Redis (see also `existingSecret`)             | `""`                                         |
-| `tasksRedis.existingSecretName`                 | Fetch password for external Redis from a different `Secret`         | `""`                                         |
-| `tasksRedis.existingSecretKey`                  | Key to fetch the password in the above `Secret`                     | `redis-password`                             |
-| `cachingRedis.database`                         | Redis database number used for caching views                        | `1`                                          |
-| `cachingRedis.ssl`                              | Enable SSL when connecting to Redis                                 | `false`                                      |
-| `cachingRedis.insecureSkipTlsVerify`            | Skip TLS certificate verification when connecting to Redis          | `false`                                      |
-| `cachingRedis.caCertPath`                       | Path to CA certificates bundle for Redis (needs mounting manually)  | `""`                                         |
-| `cachingRedis.host`                             | Redis host to use when `redis.enabled` is `false`                   | `"netbox-redis"`                             |
-| `cachingRedis.port`                             | Port number for external Redis                                      | `6379`                                       |
+| `tasksRedis.username`                           | Username for external KV                                            | `""`                                         |
+| `tasksRedis.password`                           | Password for external KV (see also `existingSecret`)                | `""`                                         |
+| `tasksRedis.existingSecretName`                 | Fetch password for external KV from a different `Secret`            | `""`                                         |
+| `tasksRedis.existingSecretKey`                  | Key to fetch the password in the above `Secret`                     | `tasks-password`                             |
+| `cachingRedis.database`                         | KV database number used for caching views                           | `1`                                          |
+| `cachingRedis.ssl`                              | Enable SSL when connecting to KV                                    | `false`                                      |
+| `cachingRedis.insecureSkipTlsVerify`            | Skip TLS certificate verification when connecting to KV             | `false`                                      |
+| `cachingRedis.caCertPath`                       | Path to CA certificates bundle for KV (needs mounting manually)     | `""`                                         |
+| `cachingRedis.host`                             | KV host to use when `valkey.enabled` is `false`                     | `"netbox-redis"`                             |
+| `cachingRedis.port`                             | Port number for external KV                                         | `6379`                                       |
 | `cachingRedis.sentinels`                        | List of sentinels in `host:port` form (`host` and `port` not used)  | `[]`                                         |
 | `cachingRedis.sentinelService`                  | Sentinel master service name                                        | `"netbox-redis"`                             |
 | `cachingRedis.sentinelTimeout`                  | Sentinel connection timeout, in seconds                             | `300` (5 minutes)                            |
-| `cachingRedis.username`                         | Username for external Redis                                         | `""`                                         |
-| `cachingRedis.password`                         | Password for external Redis (see also `existingSecret`)             | `""`                                         |
-| `cachingRedis.existingSecretName`               | Fetch password for external Redis from a different `Secret`         | `""`                                         |
-| `cachingRedis.existingSecretKey`                | Key to fetch the password in the above `Secret`                     | `redis-password`                             |
+| `cachingRedis.username`                         | Username for external KV                                            | `""`                                         |
+| `cachingRedis.password`                         | Password for external KV (see also `existingSecret`)                | `""`                                         |
+| `cachingRedis.existingSecretName`               | Fetch password for external KV from a different `Secret`            | `""`                                         |
+| `cachingRedis.existingSecretKey`                | Key to fetch the password in the above `Secret`                     | `cache-password`                             |
 | `imagePullSecrets`                              | List of `Secret` names containing private registry credentials      | `[]`                                         |
 | `nameOverride`                                  | Override the application name (`netbox`) used throughout the chart  | `""`                                         |
 | `fullnameOverride`                              | Override the full name of resources created as part of the release  | `""`                                         |
@@ -471,11 +471,17 @@ Type: `kubernetes.io/basic-auth`
 | --------------------- | ------------------------------------------------- | ---------------------------------- |
 | `postgresql-password` | The password for the external PostgreSQL database | If `postgresql.enabled` is `false` |
 
-### Redis secrets (`tasksRedis.existingSecretName` & `cachingRedis.existingSecretName`)
+### Tasks secrets (`tasksRedis.existingSecretName`)
 
 | Key              | Description                                                   | Required?                     |
 | ---------------- | ------------------------------------------------------------- | ----------------------------- |
-| `redis-password` | Password for the external Redis database (tasks and/or cache) | If `redis.enabled` is `false` |
+| `tasks-password` | Password for the external KV database (tasks and/or cache)    | If `valkey.enabled` is `false` |
+
+### Cache secrets (`cachingRedis.existingSecretName`)
+
+| Key              | Description                                                   | Required?                     |
+| ---------------- | ------------------------------------------------------------- | ----------------------------- |
+| `cache-password` | Password for the external KV database (tasks and/or cache)    | If `valkey.enabled` is `false` |
 
 ## Authentication
 

--- a/charts/netbox/files/configuration.py
+++ b/charts/netbox/files/configuration.py
@@ -61,8 +61,8 @@ provided_secret_name = os.getenv("SECRET_NAME", "netbox")
 
 DATABASE["PASSWORD"] = _read_secret(provided_secret_name, "db_password")
 EMAIL["PASSWORD"] = _read_secret(provided_secret_name, "email_password")
-REDIS["tasks"]["PASSWORD"] = _read_secret(provided_secret_name, "redis_tasks_password")
-REDIS["caching"]["PASSWORD"] = _read_secret(provided_secret_name, "redis_cache_password")
+REDIS["tasks"]["PASSWORD"] = _read_secret(provided_secret_name, "tasks_password")
+REDIS["caching"]["PASSWORD"] = _read_secret(provided_secret_name, "cache_password")
 SECRET_KEY = _read_secret(provided_secret_name, "secret_key")
 
 # Post-process certain values

--- a/charts/netbox/templates/_helpers.tpl
+++ b/charts/netbox/templates/_helpers.tpl
@@ -61,50 +61,50 @@ Name of the key in Secret that contains the PostgreSQL password
 {{- end }}
 
 {{/*
-Name of the Secret that contains the Redis tasks password
+Name of the Secret that contains the Valkey tasks password
 */}}
 {{- define "netbox.tasksRedis.secret" -}}
-  {{- if .Values.redis.enabled }}
-    {{- include "redis.secretName" .Subcharts.redis -}}
+  {{- if .Values.valkey.enabled }}
+    {{- include "valkey.secretName" .Subcharts.valkey -}}
   {{- else }}
-    {{- include "common.secrets.name" (dict "existingSecret" .Values.tasksRedis.existingSecretName "defaultNameSuffix" "redis" "context" $) }}
+    {{- include "common.secrets.name" (dict "existingSecret" .Values.tasksRedis.existingSecretName "defaultNameSuffix" "kv" "context" $) }}
   {{- end }}
 {{- end }}
 
 {{/*
-Name of the key in Secret that contains the Redis tasks password
+Name of the key in Secret that contains the Valkey tasks password
 */}}
 {{- define "netbox.tasksRedis.secretKey" -}}
-  {{- if .Values.redis.enabled -}}
-    {{- include "redis.secretPasswordKey" .Subcharts.redis -}}
+  {{- if .Values.valkey.enabled -}}
+    {{- include "valkey.secretPasswordKey" .Subcharts.valkey -}}
   {{- else if .Values.tasksRedis.existingSecretName -}}
     {{ .Values.tasksRedis.existingSecretKey }}
   {{- else -}}
-    redis_tasks_password
+    tasks_password
   {{- end -}}
 {{- end }}
 
 {{/*
-Name of the Secret that contains the Redis cache password
+Name of the Secret that contains the Valkey cache password
 */}}
 {{- define "netbox.cachingRedis.secret" -}}
-  {{- if .Values.redis.enabled }}
-    {{- include "redis.secretName" .Subcharts.redis -}}
+  {{- if .Values.valkey.enabled }}
+    {{- include "valkey.secretName" .Subcharts.valkey -}}
   {{- else }}
-    {{- include "common.secrets.name" (dict "existingSecret" .Values.cachingRedis.existingSecretName "defaultNameSuffix" "redis" "context" $) }}
+    {{- include "common.secrets.name" (dict "existingSecret" .Values.cachingDatabase.existingSecretName "defaultNameSuffix" "valkey" "context" $) }}
   {{- end }}
 {{- end }}
 
 {{/*
-Name of the key in Secret that contains the Redis cache password
+Name of the key in Secret that contains the Valkey cache password
 */}}
 {{- define "netbox.cachingRedis.secretKey" -}}
-  {{- if .Values.redis.enabled -}}
-    {{- include "redis.secretPasswordKey" .Subcharts.redis -}}
+  {{- if .Values.valkey.enabled -}}
+    {{- include "valkey.secretPasswordKey" .Subcharts.valkey -}}
   {{- else if .Values.cachingRedis.existingSecretName -}}
     {{ .Values.cachingRedis.existingSecretKey }}
   {{- else -}}
-    redis_cache_password
+    cache_password
   {{- end -}}
 {{- end }}
 

--- a/charts/netbox/templates/_helpers.tpl
+++ b/charts/netbox/templates/_helpers.tpl
@@ -63,22 +63,22 @@ Name of the key in Secret that contains the PostgreSQL password
 {{/*
 Name of the Secret that contains the Valkey tasks password
 */}}
-{{- define "netbox.tasksRedis.secret" -}}
+{{- define "netbox.tasksDatabase.secret" -}}
   {{- if .Values.valkey.enabled }}
     {{- include "valkey.secretName" .Subcharts.valkey -}}
   {{- else }}
-    {{- include "common.secrets.name" (dict "existingSecret" .Values.tasksRedis.existingSecretName "defaultNameSuffix" "kv" "context" $) }}
+    {{- include "common.secrets.name" (dict "existingSecret" .Values.tasksDatabase.existingSecretName "defaultNameSuffix" "kv" "context" $) }}
   {{- end }}
 {{- end }}
 
 {{/*
 Name of the key in Secret that contains the Valkey tasks password
 */}}
-{{- define "netbox.tasksRedis.secretKey" -}}
+{{- define "netbox.tasksDatabase.secretKey" -}}
   {{- if .Values.valkey.enabled -}}
     {{- include "valkey.secretPasswordKey" .Subcharts.valkey -}}
-  {{- else if .Values.tasksRedis.existingSecretName -}}
-    {{ .Values.tasksRedis.existingSecretKey }}
+  {{- else if .Values.tasksDatabase.existingSecretName -}}
+    {{ .Values.tasksDatabase.existingSecretKey }}
   {{- else -}}
     tasks_password
   {{- end -}}
@@ -87,7 +87,7 @@ Name of the key in Secret that contains the Valkey tasks password
 {{/*
 Name of the Secret that contains the Valkey cache password
 */}}
-{{- define "netbox.cachingRedis.secret" -}}
+{{- define "netbox.cachingDatabase.secret" -}}
   {{- if .Values.valkey.enabled }}
     {{- include "valkey.secretName" .Subcharts.valkey -}}
   {{- else }}
@@ -98,11 +98,11 @@ Name of the Secret that contains the Valkey cache password
 {{/*
 Name of the key in Secret that contains the Valkey cache password
 */}}
-{{- define "netbox.cachingRedis.secretKey" -}}
+{{- define "netbox.cachingDatabase.secretKey" -}}
   {{- if .Values.valkey.enabled -}}
     {{- include "valkey.secretPasswordKey" .Subcharts.valkey -}}
-  {{- else if .Values.cachingRedis.existingSecretName -}}
-    {{ .Values.cachingRedis.existingSecretKey }}
+  {{- else if .Values.cachingDatabase.existingSecretName -}}
+    {{ .Values.cachingDatabase.existingSecretKey }}
   {{- else -}}
     cache_password
   {{- end -}}

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -116,36 +116,36 @@ data:
         {{- if .Values.valkey.enabled }}
         HOST: {{ printf "%s-master" (include "common.names.fullname" .Subcharts.valkey) | quote }}
         PORT: {{ .Values.valkey.master.service.ports.valkey | int }}
-        {{- else if .Values.tasksRedis.sentinels }}
-        SENTINELS: {{ toJson .Values.tasksRedis.sentinels }}
-        SENTINEL_SERVICE: {{ .Values.tasksRedis.sentinelService | quote }}
-        SENTINEL_TIMEOUT: {{ .Values.tasksRedis.sentinelTimeout | int }}
+        {{- else if .Values.tasksDatabase.sentinels }}
+        SENTINELS: {{ toJson .Values.tasksDatabase.sentinels }}
+        SENTINEL_SERVICE: {{ .Values.tasksDatabase.sentinelService | quote }}
+        SENTINEL_TIMEOUT: {{ .Values.tasksDatabase.sentinelTimeout | int }}
         {{- else }}
-        HOST: {{ .Values.tasksRedis.host | quote }}
-        PORT: {{ .Values.tasksRedis.port | int }}
+        HOST: {{ .Values.tasksDatabase.host | quote }}
+        PORT: {{ .Values.tasksDatabase.port | int }}
         {{- end }}
-        USERNAME: {{ .Values.tasksRedis.username | quote }}
-        DATABASE: {{ int .Values.tasksRedis.database }}
-        SSL: {{ toJson .Values.tasksRedis.ssl }}
-        INSECURE_SKIP_TLS_VERIFY: {{ toJson .Values.tasksRedis.insecureSkipTlsVerify }}
-        CA_CERT_PATH: {{ .Values.tasksRedis.caCertPath | quote }}
+        USERNAME: {{ .Values.tasksDatabase.username | quote }}
+        DATABASE: {{ int .Values.tasksDatabase.database }}
+        SSL: {{ toJson .Values.tasksDatabase.ssl }}
+        INSECURE_SKIP_TLS_VERIFY: {{ toJson .Values.tasksDatabase.insecureSkipTlsVerify }}
+        CA_CERT_PATH: {{ .Values.tasksDatabase.caCertPath | quote }}
       caching:
         {{- if .Values.valkey.enabled }}
         HOST: {{ printf "%s-master" (include "common.names.fullname" .Subcharts.valkey) | quote }}
         PORT: {{ .Values.valkey.master.service.ports.valkey | int }}
-        {{- else if .Values.cachingRedis.sentinels }}
-        SENTINELS: {{ toJson .Values.cachingRedis.sentinels }}
-        SENTINEL_SERVICE: {{ .Values.cachingRedis.sentinelService | quote }}
-        SENTINEL_TIMEOUT: {{ .Values.cachingRedis.sentinelTimeout | int }}
+        {{- else if .Values.cachingDatabase.sentinels }}
+        SENTINELS: {{ toJson .Values.cachingDatabase.sentinels }}
+        SENTINEL_SERVICE: {{ .Values.cachingDatabase.sentinelService | quote }}
+        SENTINEL_TIMEOUT: {{ .Values.cachingDatabase.sentinelTimeout | int }}
         {{- else }}
-        HOST: {{ .Values.cachingRedis.host | quote }}
-        PORT: {{ .Values.cachingRedis.port | int}}
+        HOST: {{ .Values.cachingDatabase.host | quote }}
+        PORT: {{ .Values.cachingDatabase.port | int}}
         {{- end }}
-        USERNAME: {{ .Values.cachingRedis.username | quote }}
-        DATABASE: {{ int .Values.cachingRedis.database }}
-        SSL: {{ toJson .Values.cachingRedis.ssl }}
-        INSECURE_SKIP_TLS_VERIFY: {{ toJson .Values.cachingRedis.insecureSkipTlsVerify }}
-        CA_CERT_PATH: {{ .Values.cachingRedis.caCertPath | quote }}
+        USERNAME: {{ .Values.cachingDatabase.username | quote }}
+        DATABASE: {{ int .Values.cachingDatabase.database }}
+        SSL: {{ toJson .Values.cachingDatabase.ssl }}
+        INSECURE_SKIP_TLS_VERIFY: {{ toJson .Values.cachingDatabase.insecureSkipTlsVerify }}
+        CA_CERT_PATH: {{ .Values.cachingDatabase.caCertPath | quote }}
 
     REPORTS_ROOT: /opt/netbox/netbox/reports
     RQ_DEFAULT_TIMEOUT: {{ .Values.rqDefaultTimeout | int }}

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -113,9 +113,9 @@ data:
 
     REDIS:
       tasks:
-        {{- if .Values.redis.enabled }}
-        HOST: {{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) | quote }}
-        PORT: {{ .Values.redis.master.service.ports.redis | int }}
+        {{- if .Values.valkey.enabled }}
+        HOST: {{ printf "%s-master" (include "common.names.fullname" .Subcharts.valkey) | quote }}
+        PORT: {{ .Values.valkey.master.service.ports.valkey | int }}
         {{- else if .Values.tasksRedis.sentinels }}
         SENTINELS: {{ toJson .Values.tasksRedis.sentinels }}
         SENTINEL_SERVICE: {{ .Values.tasksRedis.sentinelService | quote }}
@@ -130,9 +130,9 @@ data:
         INSECURE_SKIP_TLS_VERIFY: {{ toJson .Values.tasksRedis.insecureSkipTlsVerify }}
         CA_CERT_PATH: {{ .Values.tasksRedis.caCertPath | quote }}
       caching:
-        {{- if .Values.redis.enabled }}
-        HOST: {{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) | quote }}
-        PORT: {{ .Values.redis.master.service.ports.redis | int }}
+        {{- if .Values.valkey.enabled }}
+        HOST: {{ printf "%s-master" (include "common.names.fullname" .Subcharts.valkey) | quote }}
+        PORT: {{ .Values.valkey.master.service.ports.valkey | int }}
         {{- else if .Values.cachingRedis.sentinels }}
         SENTINELS: {{ toJson .Values.cachingRedis.sentinels }}
         SENTINEL_SERVICE: {{ .Values.cachingRedis.sentinelService | quote }}

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -145,14 +145,14 @@ spec:
                   - key: {{ include "netbox.postgresql.secretKey" . | quote }}
                     path: db_password
               - secret:
-                  name: {{ include "netbox.tasksRedis.secret" . | quote }}
+                  name: {{ include "netbox.tasksDatabase.secret" . | quote }}
                   items:
-                  - key: {{ include "netbox.tasksRedis.secretKey" . | quote }}
+                  - key: {{ include "netbox.tasksDatabase.secretKey" . | quote }}
                     path: tasks_password
               - secret:
-                  name: {{ include "netbox.cachingRedis.secret" . | quote }}
+                  name: {{ include "netbox.cachingDatabase.secret" . | quote }}
                   items:
-                  - key: {{ include "netbox.cachingRedis.secretKey" . | quote }}
+                  - key: {{ include "netbox.cachingDatabase.secretKey" . | quote }}
                     path: cache_password
           {{- include "netbox.extraConfig.volumes" . | nindent 10 }}
           - name: netbox-tmp

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -148,12 +148,12 @@ spec:
                   name: {{ include "netbox.tasksRedis.secret" . | quote }}
                   items:
                   - key: {{ include "netbox.tasksRedis.secretKey" . | quote }}
-                    path: redis_tasks_password
+                    path: tasks_password
               - secret:
                   name: {{ include "netbox.cachingRedis.secret" . | quote }}
                   items:
                   - key: {{ include "netbox.cachingRedis.secretKey" . | quote }}
-                    path: redis_cache_password
+                    path: cache_password
           {{- include "netbox.extraConfig.volumes" . | nindent 10 }}
           - name: netbox-tmp
             emptyDir:

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -248,14 +248,14 @@ spec:
               - key: {{ include "netbox.postgresql.secretKey" . | quote }}
                 path: db_password
           - secret:
-              name: {{ include "netbox.tasksRedis.secret" . | quote }}
+              name: {{ include "netbox.tasksDatabase.secret" . | quote }}
               items:
-              - key: {{ include "netbox.tasksRedis.secretKey" . | quote }}
+              - key: {{ include "netbox.tasksDatabase.secretKey" . | quote }}
                 path: tasks_password
           - secret:
-              name: {{ include "netbox.cachingRedis.secret" . | quote }}
+              name: {{ include "netbox.cachingDatabase.secret" . | quote }}
               items:
-              - key: {{ include "netbox.cachingRedis.secretKey" . | quote }}
+              - key: {{ include "netbox.cachingDatabase.secretKey" . | quote }}
                 path: cache_password
       {{- include "netbox.extraConfig.volumes" . | nindent 6 }}
       - name: netbox-tmp

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -251,12 +251,12 @@ spec:
               name: {{ include "netbox.tasksRedis.secret" . | quote }}
               items:
               - key: {{ include "netbox.tasksRedis.secretKey" . | quote }}
-                path: redis_tasks_password
+                path: tasks_password
           - secret:
               name: {{ include "netbox.cachingRedis.secret" . | quote }}
               items:
               - key: {{ include "netbox.cachingRedis.secretKey" . | quote }}
-                path: redis_cache_password
+                path: cache_password
       {{- include "netbox.extraConfig.volumes" . | nindent 6 }}
       - name: netbox-tmp
         emptyDir:

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -52,12 +52,12 @@ type: Opaque
 data:
   db_password: {{ .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}
-{{- if not (or .Values.redis.enabled (and .Values.tasksRedis.existingSecretName .Values.cachingRedis.existingSecretName)) }}
+{{- if not (or .Values.valkey.enabled (and .Values.tasksRedis.existingSecretName .Values.cachingRedis.existingSecretName)) }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.secrets.name" (dict "defaultNameSuffix" "redis" "context" $) }}
+  name: {{ include "common.secrets.name" (dict "defaultNameSuffix" "kv" "context" $) }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
@@ -66,9 +66,9 @@ metadata:
 type: Opaque
 data:
   {{- if not .Values.tasksRedis.existingSecretName }}
-  redis_tasks_password: {{ .Values.tasksRedis.password | b64enc | quote }}
+  tasks_password: {{ .Values.tasksRedis.password | b64enc | quote }}
   {{- end }}
   {{- if not .Values.cachingRedis.existingSecretName }}
-  redis_cache_password: {{ .Values.cachingRedis.password | b64enc | quote }}
+  cache_password: {{ .Values.cachingRedis.password | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -52,7 +52,7 @@ type: Opaque
 data:
   db_password: {{ .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}
-{{- if not (or .Values.valkey.enabled (and .Values.tasksRedis.existingSecretName .Values.cachingRedis.existingSecretName)) }}
+{{- if not (or .Values.valkey.enabled (and .Values.tasksDatabase.existingSecretName .Values.cachingDatabase.existingSecretName)) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -65,10 +65,10 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- if not .Values.tasksRedis.existingSecretName }}
-  tasks_password: {{ .Values.tasksRedis.password | b64enc | quote }}
+  {{- if not .Values.tasksDatabase.existingSecretName }}
+  tasks_password: {{ .Values.tasksDatabase.password | b64enc | quote }}
   {{- end }}
-  {{- if not .Values.cachingRedis.existingSecretName }}
-  cache_password: {{ .Values.cachingRedis.password | b64enc | quote }}
+  {{- if not .Values.cachingDatabase.existingSecretName }}
+  cache_password: {{ .Values.cachingDatabase.password | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/netbox/templates/worker/deployment.yaml
+++ b/charts/netbox/templates/worker/deployment.yaml
@@ -156,14 +156,14 @@ spec:
               - key: {{ include "netbox.postgresql.secretKey" . | quote }}
                 path: db_password
           - secret:
-              name: {{ include "netbox.tasksRedis.secret" . | quote }}
+              name: {{ include "netbox.tasksDatabase.secret" . | quote }}
               items:
-              - key: {{ include "netbox.tasksRedis.secretKey" . | quote }}
+              - key: {{ include "netbox.tasksDatabase.secretKey" . | quote }}
                 path: tasks_password
           - secret:
-              name: {{ include "netbox.cachingRedis.secret" . | quote }}
+              name: {{ include "netbox.cachingDatabase.secret" . | quote }}
               items:
-              - key: {{ include "netbox.cachingRedis.secretKey" . | quote }}
+              - key: {{ include "netbox.cachingDatabase.secretKey" . | quote }}
                 path: cache_password
       {{- include "netbox.extraConfig.volumes" . | nindent 6 }}
       - name: netbox-tmp

--- a/charts/netbox/templates/worker/deployment.yaml
+++ b/charts/netbox/templates/worker/deployment.yaml
@@ -159,12 +159,12 @@ spec:
               name: {{ include "netbox.tasksRedis.secret" . | quote }}
               items:
               - key: {{ include "netbox.tasksRedis.secretKey" . | quote }}
-                path: redis_tasks_password
+                path: tasks_password
           - secret:
               name: {{ include "netbox.cachingRedis.secret" . | quote }}
               items:
               - key: {{ include "netbox.cachingRedis.secretKey" . | quote }}
-                path: redis_cache_password
+                path: cache_password
       {{- include "netbox.extraConfig.volumes" . | nindent 6 }}
       - name: netbox-tmp
         emptyDir:

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -920,9 +920,9 @@
     "readinessProbe": {
       "$ref": "#/$defs/probe"
     },
-    "redis": {
-      "title": "Redis chart configuration",
-      "description": "https://artifacthub.io/packages/helm/bitnami/redis",
+    "valkey": {
+      "title": "Valkey chart configuration",
+      "description": "https://artifacthub.io/packages/helm/bitnami/valkey",
       "properties": {
         "enabled": {
           "type": "boolean"

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -197,7 +197,7 @@
     "basePath": {
       "type": "string"
     },
-    "cachingRedis": {
+    "cachingDatabase": {
       "properties": {
         "caCertPath": {
           "type": "string"
@@ -1319,7 +1319,7 @@
       },
       "type": "object"
     },
-    "tasksRedis": {
+    "tasksDatabase": {
       "properties": {
         "caCertPath": {
           "type": "string"

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -1052,7 +1052,7 @@ externalDatabase:
 valkey:
   enabled: true
 
-tasksRedis:
+tasksDatabase:
   database: 0
   ssl: false
   insecureSkipTlsVerify: false
@@ -1061,18 +1061,18 @@ tasksRedis:
 
   # Used only when valkey.enabled is false. host and port are not used if
   # sentinels are given.
-  host: netbox-valkey
+  host: netbox-kv
   port: 6379
   sentinels: []
   #  - mysentinel:26379
-  sentinelService: netbox-valkey
+  sentinelService: netbox-kv
   sentinelTimeout: 300
   username: ""
   password: ""
   existingSecretName: ""
   existingSecretKey: tasks-password
 
-cachingRedis:
+cachingDatabase:
   database: 1
   ssl: false
   insecureSkipTlsVerify: false
@@ -1081,11 +1081,11 @@ cachingRedis:
 
   # Used only when valkey.enabled is false. host and port are not used if
   # sentinels are given.
-  host: netbox-valkey
+  host: netbox-kv
   port: 6379
   sentinels: []
   #  - mysentinel:26379
-  sentinelService: netbox-valkey
+  sentinelService: netbox-kv
   sentinelTimeout: 300
   username: ""
   password: ""

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -639,17 +639,17 @@ hostAliases: []
 ## @param extraVolumes Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`
 ## e.g:
 ## extraVolumes:
-##   - name: redis-ca
+##   - name: kv-ca
 ##     secret:
-##       secretName: redis-ca
+##       secretName: kv-ca
 ##
 extraVolumes: []
 ## @param extraVolumeMounts Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.
 ## e.g:
 ## extraVolumeMounts:
-##   - name: redis-ca
-##     mountPath: /tmp/redis-ca
-##     subPath: redis_ca
+##   - name: kv-ca
+##     mountPath: /tmp/kv-ca
+##     subPath: kv_ca
 ##     readOnly: true
 ##
 extraVolumeMounts: []
@@ -1045,11 +1045,11 @@ externalDatabase:
     sslmode: "prefer"
     target_session_attrs: "read-write"
 
-## Redis chart configuration
-## https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml
-## @param redis.enabled Deploy Redis using bundled Bitnami Redis chart
+## Valkey chart configuration
+## https://github.com/bitnami/charts/blob/main/bitnami/valkey/values.yaml
+## @param valkey.enabled Whether to deploy a Valkey server to satisfy the applications database requirements
 ##
-redis:
+valkey:
   enabled: true
 
 tasksRedis:
@@ -1059,18 +1059,18 @@ tasksRedis:
   # When defining caCertPath, make sure you mount the secret containing the CA certificate on all the necessary containers
   caCertPath: ""
 
-  # Used only when redis.enabled is false. host and port are not used if
+  # Used only when valkey.enabled is false. host and port are not used if
   # sentinels are given.
-  host: netbox-redis
+  host: netbox-valkey
   port: 6379
   sentinels: []
   #  - mysentinel:26379
-  sentinelService: netbox-redis
+  sentinelService: netbox-valkey
   sentinelTimeout: 300
   username: ""
   password: ""
   existingSecretName: ""
-  existingSecretKey: redis-password
+  existingSecretKey: tasks-password
 
 cachingRedis:
   database: 1
@@ -1079,18 +1079,18 @@ cachingRedis:
   # When defining caCertPath, make sure you mount the secret containing the CA certificate on all the necessary containers
   caCertPath: ""
 
-  # Used only when redis.enabled is false. host and port are not used if
+  # Used only when valkey.enabled is false. host and port are not used if
   # sentinels are given.
-  host: netbox-redis
+  host: netbox-valkey
   port: 6379
   sentinels: []
   #  - mysentinel:26379
-  sentinelService: netbox-redis
+  sentinelService: netbox-valkey
   sentinelTimeout: 300
   username: ""
   password: ""
   existingSecretName: ""
-  existingSecretKey: redis-password
+  existingSecretKey: cache-password
 
 ## @section Autoscaling parameters
 
@@ -1362,17 +1362,17 @@ housekeeping:
   ## @param housekeeping.extraVolumes Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`
   ## e.g:
   ## extraVolumes:
-  ##   - name: redis-ca
+  ##   - name: kv-ca
   ##     secret:
-  ##       secretName: redis-ca
+  ##       secretName: kv-ca
   ##
   extraVolumes: []
   ## @param housekeeping.extraVolumeMounts Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.
   ## e.g:
   ## extraVolumeMounts:
-  ##   - name: redis-ca
-  ##     mountPath: /tmp/redis-ca
-  ##     subPath: redis_ca
+  ##   - name: kv-ca
+  ##     mountPath: /tmp/kv-ca
+  ##     subPath: kv_ca
   ##     readOnly: true
   ##
   extraVolumeMounts: []
@@ -1599,17 +1599,17 @@ worker:
   ## @param worker.extraVolumes Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`
   ## e.g:
   ## extraVolumes:
-  ##   - name: redis-ca
+  ##   - name: kv-ca
   ##     secret:
-  ##       secretName: redis-ca
+  ##       secretName: kv-ca
   ##
   extraVolumes: []
   ## @param worker.extraVolumeMounts Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.
   ## e.g:
   ## extraVolumeMounts:
-  ##   - name: redis-ca
-  ##     mountPath: /tmp/redis-ca
-  ##     subPath: redis_ca
+  ##   - name: kv-ca
+  ##     mountPath: /tmp/kv-ca
+  ##     subPath: kv_ca
   ##     readOnly: true
   ##
   extraVolumeMounts: []


### PR DESCRIPTION
Follow up of https://github.com/netbox-community/netbox-docker/pull/1203
Bitnami chart: https://github.com/bitnami/charts/tree/HEAD/bitnami/valkey

---

- [x] Switch Redis references to Valkey
- [x] Make KV database a generic reference wherever possible
- [x] Handle `_Redis` values rewrite
- [x] ~Proper breaking change handling~ v6.0.0