### PR TITLE
Fix liveness and startup probes

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.90
+version: 5.0.0-beta.92
 appVersion: "v4.1.0"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -117,13 +117,8 @@ spec:
         {{- else if .Values.livenessProbe.enabled }}
         livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 10 }}
           httpGet:
-            path: /{{ .Values.basePath }}login/
-            port: http
-            {{- if (not (eq (index .Values.allowedHosts 0) "*")) }}
-            httpHeaders:
-            - name: Host
-              value: {{ (index .Values.allowedHosts 0) | quote }}
-            {{- end }}
+            path: /status/applications/netbox/processes/running
+            port: nginx-status
         {{- end }}
         {{- if .Values.customReadinessProbe }}
         readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 10 }}
@@ -143,8 +138,13 @@ spec:
         {{- else if .Values.startupProbe.enabled }}
         startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 10 }}
           httpGet:
-            path: /status/applications/netbox/processes/running
-            port: nginx-status
+            path: /{{ .Values.basePath }}login/
+            port: http
+            {{- if (not (eq (index .Values.allowedHosts 0) "*")) }}
+            httpHeaders:
+            - name: Host
+              value: {{ (index .Values.allowedHosts 0) | quote }}
+            {{- end }}
         {{- end }}
         {{- if .Values.lifecycleHooks }}
         lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 10 }}

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -784,7 +784,7 @@ automountServiceAccountToken: false
 ##
 livenessProbe:
   enabled: true
-  initialDelaySeconds: 5
+  initialDelaySeconds: 0
   periodSeconds: 10
   timeoutSeconds: 1
   failureThreshold: 3
@@ -801,8 +801,8 @@ livenessProbe:
 readinessProbe:
   enabled: true
   initialDelaySeconds: 0
-  timeoutSeconds: 1
   periodSeconds: 10
+  timeoutSeconds: 1
   failureThreshold: 3
   successThreshold: 1
 ## Configure extra options for startupProbe probe


### PR DESCRIPTION
Follow up of #244
This PR should improve the use of Kubernetes probes.
* Nginx status checking if the pod is still live (liveness)
* `/login` response checking if the app is still responsive (readiness, unchanged)
* `/login` response checking if the app startup is done (startup)
  * Should help to take care of migrations at startup
  * Follow up of https://github.com/netbox-community/netbox-docker/pull/1203 & https://github.com/netbox-community/netbox-docker/pull/1233