### PR TITLE
Add a schema for values validation

### DIFF
--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -1,0 +1,1522 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Netbox Helm Chart Schema",
+  "type": "object",
+  "$defs": {
+    "image": {
+      "title": "Container image description",
+      "type": "object",
+      "properties": {
+        "pullPolicy": {
+          "title": "Specify a imagePullPolicy",
+          "description": "Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'",
+          "type": "string",
+          "enum": ["IfNotPresent", "Always", "Never"]
+        },
+        "pullSecrets": {
+          "title": "Optionally specify an array of imagePullSecrets",
+          "description": "https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/",
+          "type": "array"
+        },
+        "registry": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "digest": {
+          "type": "string"
+        }
+      },
+      "required": ["repository", "pullPolicy"]
+    },
+    "probe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "failureThreshold": {
+          "type": "integer"
+        },
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "httpHeaders": {
+              "type": "array"
+            },
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": "string"
+            },
+            "scheme": {
+              "type": "string"
+            }
+          }
+        },
+        "initialDelaySeconds": {
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "type": "integer"
+        },
+        "successThreshold": {
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "type": "integer"
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "title": "Required Resources",
+      "description": "Configure resource requests",
+      "form": true,
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "memory": {
+              "type": "string",
+              "form": true,
+              "render": "slider",
+              "title": "Memory Request",
+              "sliderMin": 10,
+              "sliderMax": 2048,
+              "sliderUnit": "Mi"
+            },
+            "cpu": {
+              "type": "string",
+              "form": true,
+              "render": "slider",
+              "title": "CPU Request",
+              "sliderMin": 10,
+              "sliderMax": 2000,
+              "sliderUnit": "m"
+            }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "memory": {
+              "type": "string",
+              "form": true,
+              "render": "slider",
+              "title": "Memory Request",
+              "sliderMin": 10,
+              "sliderMax": 2048,
+              "sliderUnit": "Mi"
+            },
+            "cpu": {
+              "type": "string",
+              "form": true,
+              "render": "slider",
+              "title": "CPU Request",
+              "sliderMin": 10,
+              "sliderMax": 2000,
+              "sliderUnit": "m"
+            }
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "admins": {
+      "type": "array"
+    },
+    "affinity": {
+      "properties": {},
+      "type": "object"
+    },
+    "allowTokenRetrieval": {
+      "type": "boolean"
+    },
+    "allowedHosts": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "allowedHostsIncludesPodIP": {
+      "type": "boolean"
+    },
+    "allowedUrlSchemes": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "args": {
+      "type": "array"
+    },
+    "authPasswordValidators": {
+      "type": "array"
+    },
+    "automountServiceAccountToken": {
+      "type": "boolean"
+    },
+    "autoscaling": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "maxReplicas": {
+          "type": "integer"
+        },
+        "minReplicas": {
+          "type": "integer"
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "banner": {
+      "properties": {
+        "bottom": {
+          "type": "string"
+        },
+        "login": {
+          "type": "string"
+        },
+        "top": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "basePath": {
+      "type": "string"
+    },
+    "cachingRedis": {
+      "properties": {
+        "caCertPath": {
+          "type": "string"
+        },
+        "database": {
+          "type": "integer"
+        },
+        "existingSecretKey": {
+          "type": "string"
+        },
+        "existingSecretName": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "insecureSkipTlsVerify": {
+          "type": "boolean"
+        },
+        "password": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "sentinelService": {
+          "type": "string"
+        },
+        "sentinelTimeout": {
+          "type": "integer"
+        },
+        "sentinels": {
+          "type": "array"
+        },
+        "ssl": {
+          "type": "boolean"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "changelogRetention": {
+      "type": "integer"
+    },
+    "clusterDomain": {
+      "type": "string"
+    },
+    "command": {
+      "type": "array"
+    },
+    "commonAnnotations": {
+      "properties": {},
+      "type": "object"
+    },
+    "commonLabels": {
+      "properties": {},
+      "type": "object"
+    },
+    "cors": {
+      "properties": {
+        "originAllowAll": {
+          "type": "boolean"
+        },
+        "originRegexWhitelist": {
+          "type": "array"
+        },
+        "originWhitelist": {
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "csrf": {
+      "properties": {
+        "cookieName": {
+          "type": "string"
+        },
+        "trustedOrigins": {
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "customLivenessProbe": {
+      "properties": {},
+      "type": "object"
+    },
+    "customReadinessProbe": {
+      "properties": {},
+      "type": "object"
+    },
+    "customStartupProbe": {
+      "properties": {},
+      "type": "object"
+    },
+    "customValidators": {
+      "properties": {},
+      "type": "object"
+    },
+    "dataUploadMaxMemorySize": {
+      "type": "integer"
+    },
+    "dateFormat": {
+      "type": "string"
+    },
+    "dateTimeFormat": {
+      "type": "string"
+    },
+    "dbWaitDebug": {
+      "type": "boolean"
+    },
+    "debug": {
+      "type": "boolean"
+    },
+    "defaultLanguage": {
+      "type": "string"
+    },
+    "defaultUserPreferences": {
+      "properties": {},
+      "type": "object"
+    },
+    "email": {
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "server": {
+          "type": "string"
+        },
+        "sslCertFile": {
+          "type": "string"
+        },
+        "sslKeyFile": {
+          "type": "string"
+        },
+        "timeout": {
+          "type": "integer"
+        },
+        "useSSL": {
+          "type": "boolean"
+        },
+        "useTLS": {
+          "type": "boolean"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "enableLocalization": {
+      "type": "boolean"
+    },
+    "enforceGlobalUnique": {
+      "type": "boolean"
+    },
+    "exemptViewPermissions": {
+      "type": "array"
+    },
+    "existingSecret": {
+      "type": "string"
+    },
+    "externalDatabase": {
+      "properties": {
+        "connMaxAge": {
+          "type": "integer"
+        },
+        "database": {
+          "type": "string"
+        },
+        "disableServerSideCursors": {
+          "type": "boolean"
+        },
+        "existingSecretKey": {
+          "type": "string"
+        },
+        "existingSecretName": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "sslMode": {
+          "type": "string"
+        },
+        "targetSessionAttrs": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "extraConfig": {
+      "type": "array"
+    },
+    "extraDeploy": {
+      "type": "array"
+    },
+    "extraEnvs": {
+      "type": "array"
+    },
+    "extraVolumeMounts": {
+      "type": "array"
+    },
+    "extraVolumes": {
+      "type": "array"
+    },
+    "fieldChoices": {
+      "properties": {},
+      "type": "object"
+    },
+    "fileUploadMaxMemorySize": {
+      "type": "integer"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "global": {
+      "properties": {
+        "imagePullSecrets": {
+          "type": "array"
+        },
+        "imageRegistry": {
+          "type": "string"
+        },
+        "storageClass": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "graphQlEnabled": {
+      "type": "boolean"
+    },
+    "hostAliases": {
+      "type": "array"
+    },
+    "housekeeping": {
+      "properties": {
+        "affinity": {
+          "properties": {},
+          "type": "object"
+        },
+        "args": {
+          "type": "array"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        },
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "concurrencyPolicy": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "extraEnvs": {
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "type": "array"
+        },
+        "extraVolumes": {
+          "type": "array"
+        },
+        "failedHistoryLimit": {
+          "type": "integer"
+        },
+        "historyLimit": {
+          "type": "integer"
+        },
+        "initContainers": {
+          "type": "array"
+        },
+        "nodeSelector": {
+          "properties": {},
+          "type": "object"
+        },
+        "podAnnotations": {
+          "properties": {},
+          "type": "object"
+        },
+        "podLabels": {
+          "properties": {},
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "fsGroup": {
+              "type": "integer"
+            },
+            "fsGroupChangePolicy": {
+              "type": "string"
+            },
+            "supplementalGroups": {
+              "type": "array"
+            },
+            "sysctls": {
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "resources": {
+          "$ref": "#/$defs/resources"
+        },
+        "resourcesPreset": {
+          "type": "string"
+        },
+        "restartPolicy": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "securityContext": {
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
+            "capabilities": {
+              "properties": {
+                "drop": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "privileged": {
+              "type": "boolean"
+            },
+            "readOnlyRootFilesystem": {
+              "type": "boolean"
+            },
+            "runAsGroup": {
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "type": "integer"
+            },
+            "seLinuxOptions": {
+              "properties": {},
+              "type": "object"
+            },
+            "seccompProfile": {
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "sidecars": {
+          "type": "array"
+        },
+        "suspend": {
+          "type": "boolean"
+        },
+        "tolerations": {
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "httpProxies": {
+      "type": "string"
+    },
+    "image": {
+      "$ref": "#/$defs/image"
+    },
+    "ingress": {
+      "properties": {
+        "annotations": {
+          "properties": {},
+          "type": "object"
+        },
+        "className": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "hosts": {
+          "items": {
+            "properties": {
+              "host": {
+                "type": "string"
+              },
+              "paths": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "pathType": {
+          "type": "string"
+        },
+        "tls": {
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "init": {
+      "properties": {
+        "image": {
+          "$ref": "#/$defs/image"
+        },
+        "resources": {
+          "$ref": "#/$defs/resources"
+        },
+        "resourcesPreset": {
+          "type": "string"
+        },
+        "securityContext": {
+          "properties": {
+            "capabilities": {
+              "properties": {
+                "drop": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "readOnlyRootFilesystem": {
+              "type": "boolean"
+            },
+            "runAsGroup": {
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "type": "integer"
+            },
+            "seLinuxOptions": {
+              "properties": {},
+              "type": "object"
+            },
+            "seccompProfile": {
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "initContainers": {
+      "type": "array"
+    },
+    "internalIPs": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "jobRetention": {
+      "type": "integer"
+    },
+    "lifecycleHooks": {
+      "properties": {},
+      "type": "object"
+    },
+    "livenessProbe": {
+      "$ref": "#/$defs/probe"
+    },
+    "logging": {
+      "properties": {},
+      "type": "object"
+    },
+    "loginPersistence": {
+      "type": "boolean"
+    },
+    "loginRequired": {
+      "type": "boolean"
+    },
+    "loginTimeout": {
+      "type": "integer"
+    },
+    "logoutRedirectUrl": {
+      "type": "string"
+    },
+    "maintenanceMode": {
+      "type": "boolean"
+    },
+    "mapsUrl": {
+      "type": "string"
+    },
+    "maxPageSize": {
+      "type": "integer"
+    },
+    "metrics": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "serviceMonitor": {
+          "properties": {
+            "additionalLabels": {
+              "properties": {},
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "honorLabels": {
+              "type": "boolean"
+            },
+            "interval": {
+              "type": "string"
+            },
+            "metricRelabelings": {
+              "type": "array"
+            },
+            "relabelings": {
+              "type": "array"
+            },
+            "scrapeTimeout": {
+              "type": "string"
+            },
+            "selector": {
+              "properties": {},
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "nodeSelector": {
+      "properties": {},
+      "type": "object"
+    },
+    "overrideUnitConfig": {
+      "properties": {},
+      "type": "object"
+    },
+    "paginateCount": {
+      "type": "integer"
+    },
+    "persistence": {
+      "properties": {
+        "accessMode": {
+          "type": "string"
+        },
+        "annotations": {
+          "properties": {},
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "existingClaim": {
+          "type": "string"
+        },
+        "size": {
+          "type": "string"
+        },
+        "storageClass": {
+          "type": "string"
+        },
+        "subPath": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "plugins": {
+      "type": "array"
+    },
+    "pluginsConfig": {
+      "properties": {},
+      "type": "object"
+    },
+    "podAnnotations": {
+      "properties": {},
+      "type": "object"
+    },
+    "podLabels": {
+      "properties": {},
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "fsGroup": {
+          "type": "integer"
+        },
+        "fsGroupChangePolicy": {
+          "type": "string"
+        },
+        "supplementalGroups": {
+          "type": "array"
+        },
+        "sysctls": {
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "postgresql": {
+      "title": "PostgreSQL chart configuration",
+      "description": "https://artifacthub.io/packages/helm/bitnami/postgresql",
+      "allOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/bitnami/charts/master/bitnami/postgresql/values.schema.json"
+        },
+        {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "powerFeedDefaultAmperage": {
+      "type": "integer"
+    },
+    "powerFeedDefaultVoltage": {
+      "type": "integer"
+    },
+    "powerFeedMaxUtilisation": {
+      "type": "integer"
+    },
+    "preferIPv4": {
+      "type": "boolean"
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "rackElevationDefaultUnitHeight": {
+      "type": "integer"
+    },
+    "rackElevationDefaultUnitWidth": {
+      "type": "integer"
+    },
+    "readinessProbe": {
+      "$ref": "#/$defs/probe"
+    },
+    "redis": {
+      "title": "Redis chart configuration",
+      "description": "https://artifacthub.io/packages/helm/bitnami/redis",
+      "allOf": [
+        {
+          "$ref": "https://raw.githubusercontent.com/bitnami/charts/master/bitnami/redis/values.schema.json"
+        },
+        {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    },
+    "releaseCheck": {
+      "properties": {
+        "url": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "remoteAuth": {
+      "properties": {
+        "autoCreateGroups": {
+          "type": "boolean"
+        },
+        "autoCreateUser": {
+          "type": "boolean"
+        },
+        "backends": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "defaultGroups": {
+          "type": "array"
+        },
+        "defaultPermissions": {
+          "properties": {},
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "groupHeader": {
+          "type": "string"
+        },
+        "groupSeparator": {
+          "type": "string"
+        },
+        "groupSyncEnabled": {
+          "type": "boolean"
+        },
+        "header": {
+          "type": "string"
+        },
+        "staffGroups": {
+          "type": "array"
+        },
+        "staffUsers": {
+          "type": "array"
+        },
+        "superuserGroups": {
+          "type": "array"
+        },
+        "superusers": {
+          "type": "array"
+        },
+        "userEmail": {
+          "type": "string"
+        },
+        "userFirstName": {
+          "type": "string"
+        },
+        "userLastName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "replicaCount": {
+      "type": "integer"
+    },
+    "reportsPersistence": {
+      "properties": {
+        "accessMode": {
+          "type": "string"
+        },
+        "annotations": {
+          "properties": {},
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "existingClaim": {
+          "type": "string"
+        },
+        "size": {
+          "type": "string"
+        },
+        "storageClass": {
+          "type": "string"
+        },
+        "subPath": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "resources": {
+      "properties": {},
+      "type": "object"
+    },
+    "resourcesPreset": {
+      "type": "string"
+    },
+    "revisionHistoryLimit": {
+      "type": "integer"
+    },
+    "rqDefaultTimeout": {
+      "type": "integer"
+    },
+    "schedulerName": {
+      "type": "string"
+    },
+    "scriptsPersistence": {
+      "properties": {
+        "accessMode": {
+          "type": "string"
+        },
+        "annotations": {
+          "properties": {},
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "existingClaim": {
+          "type": "string"
+        },
+        "size": {
+          "type": "string"
+        },
+        "storageClass": {
+          "type": "string"
+        },
+        "subPath": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "secretKey": {
+      "type": "string"
+    },
+    "securityContext": {
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "type": "boolean"
+        },
+        "capabilities": {
+          "properties": {
+            "drop": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "privileged": {
+          "type": "boolean"
+        },
+        "readOnlyRootFilesystem": {
+          "type": "boolean"
+        },
+        "runAsGroup": {
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "type": "integer"
+        },
+        "seLinuxOptions": {
+          "properties": {},
+          "type": "object"
+        },
+        "seccompProfile": {
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "service": {
+      "properties": {
+        "annotations": {
+          "properties": {},
+          "type": "object"
+        },
+        "clusterIP": {
+          "type": "string"
+        },
+        "clusterIPs": {
+          "type": "array"
+        },
+        "externalIPs": {
+          "type": "array"
+        },
+        "externalTrafficPolicy": {
+          "type": "string"
+        },
+        "ipFamilyPolicy": {
+          "type": "string"
+        },
+        "loadBalancerClass": {
+          "type": "string"
+        },
+        "loadBalancerIP": {
+          "type": "string"
+        },
+        "loadBalancerSourceRanges": {
+          "type": "array"
+        },
+        "nodePort": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "sessionAffinity": {
+          "type": "string"
+        },
+        "sessionAffinityConfig": {
+          "properties": {},
+          "type": "object"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "serviceAccount": {
+      "properties": {
+        "annotations": {
+          "properties": {},
+          "type": "object"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        },
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "sessionCookieName": {
+      "type": "string"
+    },
+    "shortDateFormat": {
+      "type": "string"
+    },
+    "shortDateTimeFormat": {
+      "type": "string"
+    },
+    "shortTimeFormat": {
+      "type": "string"
+    },
+    "sidecars": {
+      "type": "array"
+    },
+    "startupProbe": {
+      "$ref": "#/$defs/probe"
+    },
+    "storageBackend": {
+      "type": "string"
+    },
+    "storageConfig": {
+      "properties": {},
+      "type": "object"
+    },
+    "superuser": {
+      "properties": {
+        "apiToken": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "existingSecret": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tasksRedis": {
+      "properties": {
+        "caCertPath": {
+          "type": "string"
+        },
+        "database": {
+          "type": "integer"
+        },
+        "existingSecretKey": {
+          "type": "string"
+        },
+        "existingSecretName": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "insecureSkipTlsVerify": {
+          "type": "boolean"
+        },
+        "password": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "sentinelService": {
+          "type": "string"
+        },
+        "sentinelTimeout": {
+          "type": "integer"
+        },
+        "sentinels": {
+          "type": "array"
+        },
+        "ssl": {
+          "type": "boolean"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "null"
+    },
+    "test": {
+      "properties": {
+        "image": {
+          "$ref": "#/$defs/image"
+        },
+        "resources": {
+          "$ref": "#/$defs/resources"
+        },
+        "resourcesPreset": {
+          "type": "string"
+        },
+        "securityContext": {
+          "properties": {
+            "capabilities": {
+              "properties": {
+                "drop": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "readOnlyRootFilesystem": {
+              "type": "boolean"
+            },
+            "runAsGroup": {
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "type": "integer"
+            },
+            "seLinuxOptions": {
+              "properties": {},
+              "type": "object"
+            },
+            "seccompProfile": {
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "timeFormat": {
+      "type": "string"
+    },
+    "timeZone": {
+      "type": "string"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "topologySpreadConstraints": {
+      "type": "array"
+    },
+    "updateStrategy": {
+      "properties": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "worker": {
+      "properties": {
+        "affinity": {
+          "properties": {},
+          "type": "object"
+        },
+        "args": {
+          "type": "array"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        },
+        "autoscaling": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "maxReplicas": {
+              "type": "integer"
+            },
+            "minReplicas": {
+              "type": "integer"
+            },
+            "targetCPUUtilizationPercentage": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "extraEnvs": {
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "type": "array"
+        },
+        "extraVolumes": {
+          "type": "array"
+        },
+        "hostAliases": {
+          "type": "array"
+        },
+        "initContainers": {
+          "type": "array"
+        },
+        "nodeSelector": {
+          "properties": {},
+          "type": "object"
+        },
+        "podAnnotations": {
+          "properties": {},
+          "type": "object"
+        },
+        "podLabels": {
+          "properties": {},
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "fsGroup": {
+              "type": "integer"
+            },
+            "fsGroupChangePolicy": {
+              "type": "string"
+            },
+            "supplementalGroups": {
+              "type": "array"
+            },
+            "sysctls": {
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "priorityClassName": {
+          "type": "string"
+        },
+        "replicaCount": {
+          "type": "integer"
+        },
+        "resources": {
+          "properties": {},
+          "type": "object"
+        },
+        "resourcesPreset": {
+          "type": "string"
+        },
+        "schedulerName": {
+          "type": "string"
+        },
+        "securityContext": {
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
+            "capabilities": {
+              "properties": {
+                "drop": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "privileged": {
+              "type": "boolean"
+            },
+            "readOnlyRootFilesystem": {
+              "type": "boolean"
+            },
+            "runAsGroup": {
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "type": "integer"
+            },
+            "seLinuxOptions": {
+              "properties": {},
+              "type": "object"
+            },
+            "seccompProfile": {
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "sidecars": {
+          "type": "array"
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "null"
+        },
+        "tolerations": {
+          "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "type": "array"
+        },
+        "updateStrategy": {
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -599,7 +599,15 @@
       "type": "object"
     },
     "httpProxies": {
-      "type": "string"
+      "properties": {
+        "http": {
+          "type": "string"
+        },
+        "https": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     },
     "image": {
       "$ref": "#/$defs/image"

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -262,7 +262,7 @@ graphQlEnabled: true
 # httpProxies:
 #   http: http://10.10.1.10:3128
 #   https: http://10.10.1.10:1080
-httpProxies: null
+httpProxies: {}
 
 # IP addresses recognized as internal to the system. The debugging toolbar will
 # be available only to clients accessing NetBox from an internal IP.
@@ -312,13 +312,13 @@ maxPageSize: 1000
 # Django-storages is also supported. Provide the class path of the storage
 # driver in storageBackend and any configuration options in storageConfig.
 # storageBackend: storages.backends.s3boto3.S3Boto3Storage
+storageBackend: ""
 # storageConfig:
 #   AWS_ACCESS_KEY_ID: 'Key ID'
 #   AWS_SECRET_ACCESS_KEY: 'Secret'
 #   AWS_STORAGE_BUCKET_NAME: 'netbox'
 #   AWS_S3_ENDPOINT_URL: 'endpoint URL of S3 provider'
 #   AWS_S3_REGION_NAME: 'eu-west-1'
-storageBackend: null
 storageConfig: {}
 
 # Determine how many objects to display per page within a list. (Default: 50)
@@ -414,8 +414,8 @@ releaseCheck:
   # This repository is used to check whether there is a new release of NetBox
   # available. Set to null to disable the version check or use the URL below to
   # check for release in the official NetBox repository.
-  url: null
   # url: https://api.github.com/repos/netbox-community/netbox/releases
+  url: ""
 
 # Maximum execution time for background tasks, in seconds.
 # Default value 300 is 5 minutes


### PR DESCRIPTION
This PR adds the `values.schema.json` file.
It is the [standard schema file](https://helm.sh/docs/topics/charts/#schema-files) for values validation.

The proposed version is relatively naive, auto-generated and without further customization.