### PR TITLE
Fix `externalDatabase` config templating

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.114
+version: 5.0.0-beta.115
 appVersion: "v4.1.2"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
       USER: {{ include "postgresql.v1.username" .Subcharts.postgresql | quote }}
       NAME: {{ include "postgresql.v1.database" .Subcharts.postgresql | quote }}
       PORT: {{ include "postgresql.v1.service.port" .Subcharts.postgresql | int }}
-      {{- else -}}
+      {{- else }}
       HOST: {{ .Values.externalDatabase.host | quote }}
       USER: {{ .Values.externalDatabase.username | quote }}
       NAME: {{ .Values.externalDatabase.database | quote }}


### PR DESCRIPTION
When using the externalDatabase option, the config.yaml is being broken by the newline removal in the else statement of the Jinja2 template:

netbox.yaml:
----
ALLOWED_HOSTS: ["*"]
ALLOWED_HOSTS_INCLUDES_POD_ID: true

DATABASE:HOST: "postgres-netbox"
  USER: "netbox"
  NAME: "netbox"
  PORT: 5432