### PR TITLE
Fix broken netbox.yaml structure with external database

### DIFF
--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
       USER: {{ include "postgresql.v1.username" .Subcharts.postgresql | quote }}
       NAME: {{ include "postgresql.v1.database" .Subcharts.postgresql | quote }}
       PORT: {{ include "postgresql.v1.service.port" .Subcharts.postgresql | int }}
-      {{- else -}}
+      {{- else }}
       HOST: {{ .Values.externalDatabase.host | quote }}
       USER: {{ .Values.externalDatabase.username | quote }}
       NAME: {{ .Values.externalDatabase.database | quote }}


### PR DESCRIPTION
Using {{- else -}} results in the following block of netbox.yaml in the netbox configmap:
```
  DATABASE:HOST: postgresql.host
    USER: netbox
```

Instead of the expected:
```
  DATABASE:
    HOST: postgresql.host
    USER: netbox
```

Which breaks the yaml structure, resulting in netbox not loading the database options.