### PR TITLE
Fix overzealous whitespace removal in helper functions for extraConfig

### DIFF
--- a/charts/netbox/templates/_helpers.tpl
+++ b/charts/netbox/templates/_helpers.tpl
@@ -115,8 +115,8 @@ Volumes that need to be mounted for .Values.extraConfig entries
   {{- else if $config.secret }}
   secret:
     {{- toYaml $config.secret | nindent 4 }}
-  {{- end }}
-{{- end }}
+  {{ end }}
+{{ end }}
 {{- end }}
 
 {{/*
@@ -127,7 +127,7 @@ Volume mounts for .Values.extraConfig entries
 - name: extra-config-{{ $index }}
   mountPath: /run/config/extra/{{ $index }}
   readOnly: true
-{{- end }}
+{{ end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
When using extraConfig, in the current version of the Helm chart, the indentation is messed up due to overzealous whitespace removal.

extraConfig looks like this:

```
extraConfig:
  - configMap:
      name: netbox-branching-config
```

When I run `helm template qs-netbox netbox/netbox --version 5.0.0-beta.122 -f values.yaml` I get the following output: `Error: YAML parse error on netbox/templates/cronjob.yaml: error converting YAML to JSON: yaml: line 63: mapping values are not allowed in this context`

Turning on debugging reveals the following rendered YAML (I've removed unnecessary content from the Cronjob):

```
# Source: netbox/templates/cronjob.yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: qs-netbox-housekeeping
spec:
  template:
    spec:
      containers:
         - name: netbox-housekeeping
            volumeMounts:
            - name: config
              mountPath: /etc/netbox/config/configuration.py
              subPath: configuration.py
              readOnly: true
            - name: config
              mountPath: /etc/netbox/config/ldap/ldap_config.py
              subPath: ldap_config.py
              readOnly: true
            - name: config
              mountPath: /run/config/netbox
              readOnly: true
            - name: secrets
              mountPath: /run/secrets/netbox
              readOnly: true
            - name: extra-config-0
              mountPath: /run/config/extra/0
              readOnly: true- name: netbox-tmp       <-------------- ERROR HERE
              mountPath: /tmp
            - name: media
              mountPath: /opt/netbox/netbox/media
              subPath: ""
            - name: reports
              mountPath: /opt/netbox/netbox/reports
              subPath: ""
            - name: scripts
              mountPath: /opt/netbox/netbox/scripts
              subPath: ""
          volumes:
          - name: config
            configMap:
              name: qs-netbox
          - name: extra-config-0
            configMap:
              name: netbox-branching-config- name: netbox-tmp    <---------------- ANOTHER ONE HERE
            emptyDir:
              medium: Memory
          - name: media
            persistentVolumeClaim:
              claimName: qs-netbox-media
          - name: reports
            persistentVolumeClaim:
              claimName: qs-netbox-reports
          - name: scripts
            persistentVolumeClaim:
              claimName: qs-netbox-scripts

```