### PR TITLE
fix: allow object types for ingress paths

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.133
+version: 5.0.0-beta.134
 appVersion: "v4.1.4"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -632,7 +632,7 @@
               },
               "paths": {
                 "items": {
-                  "type": "string"
+                  "type": ["string", "object"]
                 },
                 "type": "array"
               }


### PR DESCRIPTION
Hi,

Your helm chart [theoretically accepts object types](https://github.com/netbox-community/netbox-chart/blob/4242df109d52e55abe5db0c8ae4746385a0ebc1a/charts/netbox/templates/ingress.yaml#L32-L38) for ingress paths, however the json schema currently only allows strings. 

This PR changes the schema so both `string` and `object` types are allowed.