### PR TITLE
feat: allow the worker and housekeeping to mount the media PVC readOnly

### DIFF
--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -88,15 +88,18 @@ spec:
             - name: media
               mountPath: /opt/netbox/netbox/media
               subPath: {{ .Values.persistence.subPath | default "" | quote }}
+              readOnly: {{ .Values.housekeeping.readOnlyPersistence | default false }}
             {{- if .Values.reportsPersistence.enabled }}
             - name: reports
               mountPath: /opt/netbox/netbox/reports
               subPath: {{ .Values.reportsPersistence.subPath | default "" | quote }}
+              readOnly: {{ .Values.housekeeping.readOnlyPersistence | default false }}
             {{- end }}
             {{- if .Values.scriptsPersistence.enabled }}
             - name: scripts
               mountPath: /opt/netbox/netbox/scripts
               subPath: {{ .Values.scriptsPersistence.subPath | default "" | quote }}
+              readOnly: {{ .Values.housekeeping.readOnlyPersistence | default false }}
             {{- end }}
             {{- with .Values.housekeeping.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -150,6 +153,7 @@ spec:
             {{- if .Values.persistence.enabled }}
             persistentVolumeClaim:
               claimName: {{ .Values.persistence.existingClaim | default (printf "%s-media" (include "common.names.fullname" .)) }}
+              readOnly: {{ .Values.housekeeping.readOnlyPersistence | default false }}
             {{- else }}
             emptyDir: {}
             {{- end }}
@@ -157,11 +161,13 @@ spec:
           - name: reports
             persistentVolumeClaim:
               claimName: {{ .Values.reportsPersistence.existingClaim | default (printf "%s-reports" (include "common.names.fullname" .)) }}
+              readOnly: {{ .Values.housekeeping.readOnlyPersistence | default false }}
           {{- end }}
           {{- if .Values.scriptsPersistence.enabled }}
           - name: scripts
             persistentVolumeClaim:
               claimName: {{ .Values.scriptsPersistence.existingClaim | default (printf "%s-scripts" (include "common.names.fullname" .)) }}
+              readOnly: {{ .Values.housekeeping.readOnlyPersistence | default false }}
           {{- end }}
           {{- with .Values.housekeeping.extraVolumes }}
           {{- toYaml . | nindent 10 }}

--- a/charts/netbox/templates/worker/deployment.yaml
+++ b/charts/netbox/templates/worker/deployment.yaml
@@ -94,15 +94,18 @@ spec:
         - name: media
           mountPath: /opt/netbox/netbox/media
           subPath: {{ .Values.persistence.subPath | default "" | quote }}
+          readOnly: {{ .Values.worker.readOnlyPersistence | default false }}
         {{- if .Values.reportsPersistence.enabled }}
         - name: reports
           mountPath: /opt/netbox/netbox/reports
           subPath: {{ .Values.reportsPersistence.subPath | default "" | quote }}
+          readOnly: {{ .Values.worker.readOnlyPersistence | default false }}
         {{- end }}
         {{- if .Values.scriptsPersistence.enabled }}
         - name: scripts
           mountPath: /opt/netbox/netbox/scripts
           subPath: {{ .Values.scriptsPersistence.subPath | default "" | quote }}
+          readOnly: {{ .Values.worker.readOnlyPersistence | default false }}
         {{- end }}
         {{- with .Values.worker.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
@@ -163,6 +166,7 @@ spec:
         {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default (printf "%s-media" (include "common.names.fullname" .)) }}
+          readOnly: {{ .Values.worker.readOnlyPersistence | default false }}
         {{- else }}
         emptyDir: {}
         {{- end }}
@@ -170,11 +174,13 @@ spec:
       - name: reports
         persistentVolumeClaim:
           claimName: {{ .Values.reportsPersistence.existingClaim | default (printf "%s-reports" (include "common.names.fullname" .)) }}
+          readOnly: {{ .Values.worker.readOnlyPersistence | default false }}
       {{- end }}
       {{- if .Values.scriptsPersistence.enabled }}
       - name: scripts
         persistentVolumeClaim:
           claimName: {{ .Values.scriptsPersistence.existingClaim | default (printf "%s-scripts" (include "common.names.fullname" .)) }}
+          readOnly: {{ .Values.worker.readOnlyPersistence | default false }}
       {{- end }}
       {{- with .Values.worker.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -1324,6 +1324,9 @@ housekeeping:
   ##     memory: 1024Mi
   ##
   resources: {}
+  ## @param housekeeping.readOnlyPersistence Whether to mount media, script, and report directories as read-only
+  ##
+  readOnlyPersistence: false
   ## @param housekeeping.extraEnvs Extra environment variables to be set on containers
   ## E.g:
   ## extraEnvs:
@@ -1480,6 +1483,9 @@ worker:
   ##     memory: 1024Mi
   ##
   resources: {}
+  ## @param worker.readOnlyPersistence Whether to mount media, script, and report directories as read-only
+  ##
+  readOnlyPersistence: false
   ## @param worker.automountServiceAccountToken Mount Service Account token in pod
   ##
   automountServiceAccountToken: false


### PR DESCRIPTION
This PR lets you mount things readOnly on the worker and housekeeping so you don't need `ReadWriteMany` on the PVC to share it between the pods.