### PR TITLE
Tweak YAML rendering using common render helpers

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.151
+version: 5.0.0-beta.152
 appVersion: "v4.1.7"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/_helpers.tpl
+++ b/charts/netbox/templates/_helpers.tpl
@@ -102,7 +102,7 @@ Volumes that need to be mounted for .Values.extraConfig entries
 */}}
 {{- define "netbox.extraConfig.volumes" -}}
 {{- range $index, $config := .Values.extraConfig }}
-- name: extra-config-{{ $index }}
+- name: {{ printf "extra-config-%s" $index | quote }}
   {{- if $config.values }}
   configMap:
     name: {{ include "common.names.fullname" $ }}
@@ -111,10 +111,10 @@ Volumes that need to be mounted for .Values.extraConfig entries
       path: extra-{{ $index }}.yaml
   {{- else if $config.configMap }}
   configMap:
-    {{- toYaml $config.configMap | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" $config.configMap "context" $) | nindent 4 }}
   {{- else if $config.secret }}
   secret:
-    {{- toYaml $config.secret | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" $config.secret "context" $) | nindent 4 }}
   {{- end }}
 {{- end }}
 {{- end }}
@@ -124,7 +124,7 @@ Volume mounts for .Values.extraConfig entries
 */}}
 {{- define "netbox.extraConfig.volumeMounts" -}}
 {{- range $index, $config := .Values.extraConfig }}
-- name: extra-config-{{ $index }}
+- name: {{ printf "extra-config-%s" $index | quote }}
   mountPath: /run/config/extra/{{ $index }}
   readOnly: true
 {{- end }}

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -82,7 +82,7 @@ data:
     MEDIA_ROOT: /opt/netbox/netbox/media
     {{- if .Values.storageBackend }}
     STORAGE_BACKEND: {{ .Values.storageBackend | quote }}
-    STORAGE_CONFIG:  {{ toJson .Values.storageConfig }}
+    STORAGE_CONFIG: {{ toJson .Values.storageConfig }}
     {{- end }}
     METRICS_ENABLED: {{ toJson .Values.metrics.enabled }}
     PAGINATE_COUNT: {{ int .Values.paginateCount }}
@@ -208,7 +208,7 @@ data:
 
   {{- range $index, $config := .Values.extraConfig }}
   {{- if $config.values }}
-  extra-{{ $index }}.yaml: |-
-    {{- toYaml $config.values | nindent 4 }}
+  {{ printf "extra-%s.yaml" $index }}: |-
+    {{- include "common.tplvalues.render" (dict "value" $config.values "context" $) | nindent 4 }}
   {{- end }}
   {{- end }}

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -22,22 +22,18 @@ spec:
     spec:
       template:
         metadata:
-          {{- with .Values.housekeeping.podAnnotations }}
+          {{- if .Values.housekeeping.podAnnotations }}
           annotations:
-            {{- toYaml . | nindent 12 }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.housekeeping.podAnnotations "context" $ ) | nindent 12 }}
           {{- end }}
-          labels:
-            {{- include "common.labels.matchLabels" . | nindent 12 }}
+          labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.housekeeping.podLabels "context" $ ) | nindent 12 }}
             app.kubernetes.io/component: housekeeping
-            {{- with .Values.housekeeping.podLabels }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
         spec:
           {{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) | nindent 10 }}
           serviceAccountName: {{ include "netbox.serviceAccountName" . }}
           automountServiceAccountToken: {{ .Values.housekeeping.automountServiceAccountToken }}
           {{- if .Values.housekeeping.podSecurityContext.enabled }}
-          securityContext: {{- omit .Values.housekeeping.podSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.housekeeping.podSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.housekeeping.initContainers }}
           initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.housekeeping.initContainers "context" $) | trim | nindent 12 }}
@@ -45,7 +41,7 @@ spec:
           containers:
           - name: {{ .Chart.Name }}-housekeeping
             {{- if .Values.housekeeping.securityContext.enabled }}
-            securityContext: {{- omit .Values.housekeeping.securityContext "enabled" | toYaml | nindent 14 }}
+            securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.housekeeping.securityContext "context" $) | nindent 14 }}
             {{- end }}
             image: {{ include "netbox.image" . | quote }}
             imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -55,9 +51,19 @@ spec:
             {{- if .Values.housekeeping.args }}
             args: {{- include "common.tplvalues.render" (dict "value" .Values.housekeeping.args "context" $) | nindent 14 }}
             {{- end }}
-            {{- with .Values.housekeeping.extraEnvs }}
-            env:
-            {{- toYaml . | nindent 12 }}
+            {{- if .Values.housekeeping.extraEnvs }}
+            env: {{- include "common.tplvalues.render" (dict "value" .Values.housekeeping.extraEnvs "context" $) | nindent 14 }}
+            {{- end }}
+            {{- if or .Values.housekeeping.extraEnvVarsCM .Values.housekeeping.extraEnvVarsSecret }}
+            envFrom:
+              {{- if .Values.housekeeping.extraEnvVarsCM }}
+              - configMapRef:
+                  name: {{ include "common.tplvalues.render" (dict "value" .Values.housekeeping.extraEnvVarsCM "context" $) }}
+              {{- end }}
+              {{- if .Values.housekeeping.extraEnvVarsSecret }}
+              - secretRef:
+                  name: {{ include "common.tplvalues.render" (dict "value" .Values.housekeeping.extraEnvVarsSecret "context" $) }}
+              {{- end }}
             {{- end }}
             volumeMounts:
             - name: config
@@ -101,8 +107,8 @@ spec:
               subPath: {{ .Values.scriptsPersistence.subPath | default "" | quote }}
               readOnly: {{ .Values.housekeeping.readOnlyPersistence | default false }}
             {{- end }}
-            {{- with .Values.housekeeping.extraVolumeMounts }}
-            {{- toYaml . | nindent 12 }}
+            {{- if .Values.housekeeping.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.housekeeping.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
             {{- if .Values.housekeeping.resources }}
             resources: {{ toYaml .Values.housekeeping.resources | nindent 14 }}
@@ -169,20 +175,17 @@ spec:
               claimName: {{ .Values.scriptsPersistence.existingClaim | default (printf "%s-scripts" (include "common.names.fullname" .)) }}
               readOnly: {{ .Values.housekeeping.readOnlyPersistence | default false }}
           {{- end }}
-          {{- with .Values.housekeeping.extraVolumes }}
-          {{- toYaml . | nindent 10 }}
+          {{- if .Values.housekeeping.extraVolumes }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.housekeeping.extraVolumes "context" $) | nindent 10 }}
           {{- end }}
-          {{- with .Values.housekeeping.nodeSelector }}
-          nodeSelector:
-            {{- toYaml . | nindent 12 }}
+          {{- if .Values.housekeeping.nodeSelector }}
+          nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.housekeeping.nodeSelector "context" $) | nindent 12 }}
           {{- end }}
-          {{- with .Values.housekeeping.affinity }}
-          affinity:
-            {{- toYaml . | nindent 12 }}
+          {{- if .Values.housekeeping.affinity }}
+          affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.housekeeping.affinity "context" $) | nindent 12 }}
           {{- end }}
-          {{- with .Values.housekeeping.tolerations }}
-          tolerations:
-            {{- toYaml . | nindent 12 }}
+          {{- if .Values.housekeeping.tolerations }}
+          tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.housekeeping.tolerations "context" .) | nindent 12 }}
           {{- end }}
           restartPolicy: {{ .Values.housekeeping.restartPolicy }}
 {{- end -}}

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -14,35 +14,29 @@ spec:
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
-    matchLabels:
-      {{- include "common.labels.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" (dict "customLabels" .Values.podLabels "context" $) | nindent 6 }}
       app.kubernetes.io/component: netbox
   {{- if .Values.updateStrategy }}
-  strategy:
-    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  strategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $) | nindent 4 }}
   {{- end }}
   template:
     metadata:
       annotations:
+        {{- if .Values.podAnnotations }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $ ) | nindent 8 }}
+        {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if (not .Values.existingSecret) }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
-        {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-      labels:
-        {{- include "common.labels.matchLabels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.podLabels "context" $ ) | nindent 8 }}
         app.kubernetes.io/component: netbox
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
     spec:
       {{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) | nindent 6 }}
       serviceAccountName: {{ include "netbox.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       initContainers:
       - name: init-dirs
@@ -55,7 +49,7 @@ spec:
         resources: {{- include "common.resources.preset" (dict "type" .Values.init.resourcesPreset) | nindent 10 }}
         {{- end }}
         {{- if .Values.init.securityContext.enabled }}
-        securityContext: {{- omit .Values.init.securityContext "enabled" | toYaml | nindent 10 }}
+        securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.init.securityContext "context" $) | nindent 10 }}
         {{- end }}
         volumeMounts:
         - name: optunit
@@ -66,7 +60,7 @@ spec:
       containers:
       - name: {{ .Chart.Name }}
         {{- if .Values.securityContext.enabled }}
-        securityContext: {{- omit .Values.securityContext "enabled" | toYaml | nindent 10 }}
+        securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.securityContext "context" $) | nindent 10 }}
         {{- end }}
         image: {{ include "netbox.image" . | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -95,15 +89,26 @@ spec:
         - name: UNIT_CONFIG
           value: /run/config/netbox/nginx-unit.json
         {{- end }}
-        {{- with .Values.extraEnvs }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
         {{- if .Values.allowedHostsIncludesPodIP }}
         - name: POD_IP
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
+        {{- end }}
+        {{- if .Values.extraEnvs }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvs "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+        envFrom:
+          {{- if .Values.extraEnvVarsCM }}
+          - configMapRef:
+              name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+          {{- end }}
+          {{- if .Values.extraEnvVarsSecret }}
+          - secretRef:
+              name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+          {{- end }}
         {{- end }}
         ports:
         - name: http
@@ -202,7 +207,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 8 }}
         {{- end }}
         {{- if .Values.resources }}
-        resources: {{ toYaml .Values.resources | nindent 10 }}
+        resources: {{- toYaml .Values.resources | nindent 10 }}
         {{- else if ne .Values.resourcesPreset "none" }}
         resources: {{- include "common.resources.preset" (dict "type" .Values.resourcesPreset) | nindent 10 }}
         {{- end }}
@@ -273,8 +278,8 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.scriptsPersistence.existingClaim | default (printf "%s-scripts" (include "common.names.fullname" .)) }}
       {{- end }}
-      {{- with .Values.extraVolumes }}
-      {{- toYaml . | nindent 6 }}
+      {{- if .Values.extraVolumes }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 6 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.nodeSelector "context" $) | nindent 8 }}

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -35,7 +35,7 @@ data:
   email: {{ .Values.superuser.email | b64enc | quote }}
   api_token: {{ .Values.superuser.apiToken | default uuidv4 | b64enc | quote }}
 {{- end }}
-{{- if not (or .Values.postgresql.enabled  .Values.externalDatabase.existingSecretName) }}
+{{- if not (or .Values.postgresql.enabled .Values.externalDatabase.existingSecretName) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/netbox/templates/tests/test-connection.yaml
+++ b/charts/netbox/templates/tests/test-connection.yaml
@@ -19,6 +19,6 @@ spec:
     resources: {{- include "common.resources.preset" (dict "type" .Values.test.resourcesPreset) | nindent 6 }}
     {{- end }}
     {{- if .Values.test.securityContext.enabled }}
-    securityContext: {{- omit .Values.test.securityContext "enabled" | toYaml | nindent 6 }}
+    securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.test.securityContext "context" $) | nindent 6 }}
     {{- end }}
   restartPolicy: Never

--- a/charts/netbox/templates/worker/deployment.yaml
+++ b/charts/netbox/templates/worker/deployment.yaml
@@ -15,35 +15,29 @@ spec:
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
-    matchLabels:
-      {{- include "common.labels.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" (dict "customLabels" .Values.worker.podLabels "context" $) | nindent 6 }}
       app.kubernetes.io/component: worker
   {{- if .Values.worker.updateStrategy }}
-  strategy:
-    {{- toYaml .Values.worker.updateStrategy | nindent 4 }}
+  strategy: {{- include "common.tplvalues.render" (dict "value" .Values.worker.updateStrategy "context" $) | nindent 4 }}
   {{- end }}
   template:
     metadata:
       annotations:
+        {{- if .Values.worker.podAnnotations }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.worker.podAnnotations "context" $ ) | nindent 8 }}
+        {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if (not .Values.existingSecret) }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
-        {{- with .Values.worker.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-      labels:
-        {{- include "common.labels.matchLabels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.worker.podLabels "context" $ ) | nindent 8 }}
         app.kubernetes.io/component: worker
-        {{- with .Values.worker.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
     spec:
       {{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) | nindent 6 }}
       serviceAccountName: {{ include "netbox.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.worker.automountServiceAccountToken }}
       {{- if .Values.worker.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.worker.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.worker.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.worker.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.worker.initContainers "context" $) | trim | nindent 8 }}
@@ -51,7 +45,7 @@ spec:
       containers:
       - name: {{ .Chart.Name }}-worker
         {{- if .Values.worker.securityContext.enabled }}
-        securityContext: {{- omit .Values.worker.securityContext "enabled" | toYaml | nindent 10 }}
+        securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.worker.securityContext "context" $) | nindent 10 }}
         {{- end }}
         image: {{ include "netbox.image" . | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -61,9 +55,19 @@ spec:
         {{- if .Values.worker.args }}
         args: {{- include "common.tplvalues.render" (dict "value" .Values.worker.args "context" $) | nindent 10 }}
         {{- end }}
-        {{- with .Values.worker.extraEnvs }}
-        env:
-        {{- toYaml . | nindent 8 }}
+        {{- if .Values.worker.extraEnvs }}
+        env: {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvs "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if or .Values.worker.extraEnvVarsCM .Values.worker.extraEnvVarsSecret }}
+        envFrom:
+          {{- if .Values.worker.extraEnvVarsCM }}
+          - configMapRef:
+              name: {{ include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvVarsCM "context" $) }}
+          {{- end }}
+          {{- if .Values.worker.extraEnvVarsSecret }}
+          - secretRef:
+              name: {{ include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvVarsSecret "context" $) }}
+          {{- end }}
         {{- end }}
         volumeMounts:
         - name: config
@@ -107,8 +111,8 @@ spec:
           subPath: {{ .Values.scriptsPersistence.subPath | default "" | quote }}
           readOnly: {{ .Values.worker.readOnlyPersistence | default false }}
         {{- end }}
-        {{- with .Values.worker.extraVolumeMounts }}
-        {{- toYaml . | nindent 8 }}
+        {{- if .Values.worker.extraVolumeMounts }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumeMounts "context" $) | nindent 8 }}
         {{- end }}
         {{- if .Values.worker.resources }}
         resources: {{ toYaml .Values.worker.resources | nindent 10 }}
@@ -182,8 +186,8 @@ spec:
           claimName: {{ .Values.scriptsPersistence.existingClaim | default (printf "%s-scripts" (include "common.names.fullname" .)) }}
           readOnly: {{ .Values.worker.readOnlyPersistence | default false }}
       {{- end }}
-      {{- with .Values.worker.extraVolumes }}
-      {{- toYaml . | nindent 6 }}
+      {{- if .Values.worker.extraVolumes }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumes "context" $) | nindent 6 }}
       {{- end }}
       {{- if .Values.worker.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.worker.nodeSelector "context" $) | nindent 8 }}

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -415,6 +415,16 @@
     "extraEnvs": {
       "type": "array"
     },
+    "extraEnvVarsCM": {
+      "type": "string",
+      "description": "Name of existing ConfigMap containing extra env vars",
+      "default": ""
+    },
+    "extraEnvVarsSecret": {
+      "type": "string",
+      "description": "Name of existing Secret containing extra env vars",
+      "default": ""
+    },
     "extraVolumeMounts": {
       "type": "array"
     },
@@ -477,6 +487,16 @@
         },
         "extraEnvs": {
           "type": "array"
+        },
+        "extraEnvVarsCM": {
+          "type": "string",
+          "description": "Name of existing ConfigMap containing extra env vars",
+          "default": ""
+        },
+        "extraEnvVarsSecret": {
+          "type": "string",
+          "description": "Name of existing Secret containing extra env vars",
+          "default": ""
         },
         "extraVolumeMounts": {
           "type": "array"
@@ -1396,6 +1416,16 @@
         },
         "extraEnvs": {
           "type": "array"
+        },
+        "extraEnvVarsCM": {
+          "type": "string",
+          "description": "Name of existing ConfigMap containing extra env vars",
+          "default": ""
+        },
+        "extraEnvVarsSecret": {
+          "type": "string",
+          "description": "Name of existing Secret containing extra env vars",
+          "default": ""
         },
         "extraVolumeMounts": {
           "type": "array"

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -850,6 +850,12 @@ lifecycleHooks: {}
 ##         key: FOO
 ##         name: secret-resource
 extraEnvs: []
+## @param extraEnvVarsCM Name of existing ConfigMap containing extra env vars for containers
+##
+extraEnvVarsCM: ""
+## @param extraEnvVarsSecret Name of existing Secret containing extra env vars for containers
+##
+extraEnvVarsSecret: ""
 
 ## Configure revision history limit for deployments
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy
@@ -1336,6 +1342,12 @@ housekeeping:
   ##         key: FOO
   ##         name: secret-resource
   extraEnvs: []
+  ## @param housekeeping.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for housekeeping containers
+  ##
+  extraEnvVarsCM: ""
+  ## @param housekeeping.extraEnvVarsSecret Name of existing Secret containing extra env vars for housekeeping containers
+  ##
+  extraEnvVarsSecret: ""
   ## @param housekeeping.extraVolumes Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`
   ## e.g:
   ## extraVolumes:
@@ -1567,6 +1579,12 @@ worker:
   ##         key: FOO
   ##         name: secret-resource
   extraEnvs: []
+  ## @param worker.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for worker containers
+  ##
+  extraEnvVarsCM: ""
+  ## @param worker.extraEnvVarsSecret Name of existing Secret containing extra env vars for worker containers
+  ##
+  extraEnvVarsSecret: ""
   ## @param worker.extraVolumes Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`
   ## e.g:
   ## extraVolumes:


### PR DESCRIPTION
Tweak YAML rendering using common render helpers, and resolves https://github.com/netbox-community/netbox-chart/issues/403.
Helps to reduce mistake surface in the rendering.

Also add `extraEnvVarsCM` and `extraEnvVarsSecret` as shortcuts to gather vars from CM or Secret directly.