### PR TITLE
External secret for email password

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.157
+version: 5.0.0-beta.158
 appVersion: "v4.1.7"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/_helpers.tpl
+++ b/charts/netbox/templates/_helpers.tpl
@@ -26,17 +26,6 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Name of the Secret that contains the email password
-*/}}
-{{- define "netbox.email.secret" -}}
-  {{- if .Values.email.existingSecretName }}
-    {{- .Values.email.existingSecretName }}
-  {{- else }}
-    {{- .Values.existingSecret | default (include "common.names.fullname" .) }}
-  {{- end }}
-{{- end }}
-
-{{/*
 Name of the key in Secret that contains the email password
 */}}
 {{- define "netbox.email.secretKey" -}}

--- a/charts/netbox/templates/_helpers.tpl
+++ b/charts/netbox/templates/_helpers.tpl
@@ -26,6 +26,28 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Name of the Secret that contains the email password
+*/}}
+{{- define "netbox.email.secret" -}}
+  {{- if .Values.email.existingSecretName }}
+    {{- .Values.email.existingSecretName }}
+  {{- else }}
+    {{- .Values.existingSecret | default (include "common.names.fullname" .) }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Name of the key in Secret that contains the email password
+*/}}
+{{- define "netbox.email.secretKey" -}}
+  {{- if .Values.email.existingSecretName -}}
+    {{- .Values.email.existingSecretKey -}}
+  {{- else -}}
+    email_password
+  {{- end -}}
+{{- end }}
+
+{{/*
 Name of the Secret that contains the PostgreSQL password
 */}}
 {{- define "netbox.postgresql.secret" -}}

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -128,14 +128,17 @@ spec:
               - secret:
                   name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "defaultNameSuffix" "config" "context" $) }}
                   items:
-                  - key: email_password
-                    path: email_password
                   - key: secret_key
                     path: secret_key
                   {{- if has "netbox.authentication.LDAPBackend" .Values.remoteAuth.backends }}
                   - key: ldap_bind_password
                     path: ldap_bind_password
                   {{- end }}
+              - secret:
+                  name: {{ include "netbox.email.secret" . | quote }}
+                  items:
+                  - key: {{ include "netbox.email.secretKey" . | quote }}
+                    path: email_password
               - secret:
                   name: {{ include "netbox.postgresql.secret" . | quote }}
                   items:

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -135,7 +135,7 @@ spec:
                     path: ldap_bind_password
                   {{- end }}
               - secret:
-                  name: {{ include "netbox.email.secret" . | quote }}
+                  name: {{ include "common.secrets.name" (dict "existingSecret" (default .Values.email.existingSecretName .Values.existingSecret) "defaultNameSuffix" "config" "context" $) }}
                   items:
                   - key: {{ include "netbox.email.secretKey" . | quote }}
                     path: email_password

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -224,14 +224,17 @@ spec:
           - secret:
               name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "defaultNameSuffix" "config" "context" $) }}
               items:
-              - key: email_password
-                path: email_password
               - key: secret_key
                 path: secret_key
               {{- if has "netbox.authentication.LDAPBackend" .Values.remoteAuth.backends }}
               - key: ldap_bind_password
                 path: ldap_bind_password
               {{- end }}
+          - secret:
+              name: {{ include "netbox.email.secret" . | quote }}
+              items:
+              - key: {{ include "netbox.email.secretKey" . | quote }}
+                path: email_password
           - secret:
               name: {{ include "common.secrets.name" (dict "existingSecret" .Values.superuser.existingSecret "defaultNameSuffix" "superuser" "context" $) }}
               items:

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -231,7 +231,7 @@ spec:
                 path: ldap_bind_password
               {{- end }}
           - secret:
-              name: {{ include "netbox.email.secret" . | quote }}
+              name: {{ include "common.secrets.name" (dict "existingSecret" (default .Values.email.existingSecretName .Values.existingSecret) "defaultNameSuffix" "config" "context" $) }}
               items:
               - key: {{ include "netbox.email.secretKey" . | quote }}
                 path: email_password

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -11,7 +11,9 @@ metadata:
   {{- end }}
 type: Opaque
 data:
+  {{- if not .Values.email.existingSecretName }}
   email_password: {{ .Values.email.password | b64enc | quote }}
+  {{- end }}
   secret_key: {{ .Values.secretKey | default (randAscii 60) | b64enc | quote }}
   {{- if has "netbox.authentication.LDAPBackend" .Values.remoteAuth.backends }}
   ldap_bind_password: {{ .Values.remoteAuth.ldap.bindPassword | b64enc | quote }}

--- a/charts/netbox/templates/worker/deployment.yaml
+++ b/charts/netbox/templates/worker/deployment.yaml
@@ -139,7 +139,7 @@ spec:
                 path: ldap_bind_password
               {{- end }}
           - secret:
-              name: {{ include "netbox.email.secret" . | quote }}
+              name: {{ include "common.secrets.name" (dict "existingSecret" (default .Values.email.existingSecretName .Values.existingSecret) "defaultNameSuffix" "config" "context" $) }}
               items:
               - key: {{ include "netbox.email.secretKey" . | quote }}
                 path: email_password

--- a/charts/netbox/templates/worker/deployment.yaml
+++ b/charts/netbox/templates/worker/deployment.yaml
@@ -132,14 +132,17 @@ spec:
           - secret:
               name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "defaultNameSuffix" "config" "context" $) }}
               items:
-              - key: email_password
-                path: email_password
               - key: secret_key
                 path: secret_key
               {{- if has "netbox.authentication.LDAPBackend" .Values.remoteAuth.backends }}
               - key: ldap_bind_password
                 path: ldap_bind_password
               {{- end }}
+          - secret:
+              name: {{ include "netbox.email.secret" . | quote }}
+              items:
+              - key: {{ include "netbox.email.secretKey" . | quote }}
+                path: email_password
           - secret:
               name: {{ include "common.secrets.name" (dict "existingSecret" .Values.superuser.existingSecret "defaultNameSuffix" "superuser" "context" $) }}
               items:

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -222,6 +222,8 @@ email:
   # Timeout in seconds
   timeout: 10
   from: ""
+  existingSecretName: ""
+  existingSecretKey: email-password
 
 # Enforcement of unique IP space can be toggled on a per-VRF basis. To enforce
 # unique IP space within the global table (all prefixes and IP addresses not


### PR DESCRIPTION
Noticed that this was one of the only credentials I couldn't slap into an external secret and source from the chart. This should allow that functionality. I did test locally and it looked like it put the value in all of the right places. Didn't find a whole lot about guidelines on contributing, so let me know if there's anything additional I need to do. Thanks!