### PR TITLE
Suggestion: Update the default resourcePreset to medium

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.158
+version: 5.0.0-beta.159
 appVersion: "v4.1.7"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -721,7 +721,7 @@ topologySpreadConstraints: []
 ## This is ignored if resources is set (resources is recommended for production).
 ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
 ##
-resourcesPreset: "small"
+resourcesPreset: "medium"
 ## Containers' resource requests and limits
 ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
 ## @param resources.limits The resources limits for the container


### PR DESCRIPTION
While setting up NetBox with the Helm chart, I observed crashes even as the sole user on a fresh, empty instance. 
These "crashes" were caused by the OOM killer, as the small resourcePreset with 768Mi memory was insufficient.

Memory usage sometimes spiked during basic operations, leading to process termination. 
Switching to the medium preset resolved the issue, and I have not experienced issues since.

Although I understand it's good practice to keep resource preset as low as possible, the current default may confuse novice users who might not understand why their application is unstable. 
Changing the default to medium could provide a more robust out-of-the-box experience.