### PR TITLE
Improve database client options templating

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.173
+version: 5.0.0-beta.174
 appVersion: "v4.1.8"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -208,11 +208,9 @@ The following table lists the configurable parameters for this chart and their d
 | `externalDatabase.password`                     | Password for external PostgreSQL (see also `existingSecret`)        | `""`                                         |
 | `externalDatabase.existingSecretName`           | Fetch password for external PostgreSQL from a different `Secret`    | `""`                                         |
 | `externalDatabase.existingSecretKey`            | Key to fetch the password in the above `Secret`                     | `postgresql-password`                        |
-| `externalDatabase.sslMode`                      | PostgreSQL client SSL Mode setting                                  | `prefer`                                     |
-| `externalDatabase.sslRootCert`                  | PostgreSQL client SSL Root Certificate setting                      | `""`                                         |
 | `externalDatabase.connMaxAge`                   | The lifetime of a database connection, as an integer of seconds     | `300`                                        |
 | `externalDatabase.disableServerSideCursors`     | Disable the use of server-side cursors transaction pooling          | `false`                                      |
-| `externalDatabase.targetSessionAttrs`           | Determines whether the session must have certain properties         | `read-write`                                 |
+| `externalDatabase.options`                      | Additional PostgreSQL client parameters             | `{}`                                            |
 | `redis.enabled`                                 | Deploy Redis using bundled Bitnami Redis chart                      | `true`                                       |
 | `redis.*`                                       | Values under this key are passed to the bundled Redis chart         | n/a                                          |
 | `tasksRedis.database`                           | Redis database number used for NetBox task queue                    | `0`                                          |

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -209,7 +209,7 @@ The following table lists the configurable parameters for this chart and their d
 | `externalDatabase.existingSecretName`           | Fetch password for external PostgreSQL from a different `Secret`    | `""`                                         |
 | `externalDatabase.existingSecretKey`            | Key to fetch the password in the above `Secret`                     | `postgresql-password`                        |
 | `externalDatabase.sslMode`                      | PostgreSQL client SSL Mode setting                                  | `prefer`                                     |
-| `externalDatabase.sslRootCert`                  | PostgreSQL client SSL Root Certificate setting                      | `null`                                       |
+| `externalDatabase.sslRootCert`                  | PostgreSQL client SSL Root Certificate setting                      | `""`                                         |
 | `externalDatabase.connMaxAge`                   | The lifetime of a database connection, as an integer of seconds     | `300`                                        |
 | `externalDatabase.disableServerSideCursors`     | Disable the use of server-side cursors transaction pooling          | `false`                                      |
 | `externalDatabase.targetSessionAttrs`           | Determines whether the session must have certain properties         | `read-write`                                 |

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -209,6 +209,7 @@ The following table lists the configurable parameters for this chart and their d
 | `externalDatabase.existingSecretName`           | Fetch password for external PostgreSQL from a different `Secret`    | `""`                                         |
 | `externalDatabase.existingSecretKey`            | Key to fetch the password in the above `Secret`                     | `postgresql-password`                        |
 | `externalDatabase.sslMode`                      | PostgreSQL client SSL Mode setting                                  | `prefer`                                     |
+| `externalDatabase.sslRootCert`                  | PostgreSQL client SSL Root Certificate setting                      | `null`                                       |
 | `externalDatabase.connMaxAge`                   | The lifetime of a database connection, as an integer of seconds     | `300`                                        |
 | `externalDatabase.disableServerSideCursors`     | Disable the use of server-side cursors transaction pooling          | `false`                                      |
 | `externalDatabase.targetSessionAttrs`           | Determines whether the session must have certain properties         | `read-write`                                 |

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -29,6 +29,9 @@ data:
       {{- end }}
       OPTIONS:
         sslmode: {{ .Values.externalDatabase.sslMode | quote }}
+        {{- if .Values.externalDatabase.sslRootCert }}
+        sslrootcert: {{ .Values.externalDatabase.sslRootCert | quote }}
+        {{- end}}
         target_session_attrs: {{ .Values.externalDatabase.targetSessionAttrs | default "read-write" | quote }}
       CONN_MAX_AGE: {{ .Values.externalDatabase.connMaxAge | int }}
       DISABLE_SERVER_SIDE_CURSORS: {{ toJson .Values.externalDatabase.disableServerSideCursors }}

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -27,12 +27,7 @@ data:
       NAME: {{ .Values.externalDatabase.database | quote }}
       PORT: {{ .Values.externalDatabase.port | int }}
       {{- end }}
-      OPTIONS:
-        sslmode: {{ .Values.externalDatabase.sslMode | quote }}
-        {{- if .Values.externalDatabase.sslRootCert }}
-        sslrootcert: {{ .Values.externalDatabase.sslRootCert | quote }}
-        {{- end}}
-        target_session_attrs: {{ .Values.externalDatabase.targetSessionAttrs | default "read-write" | quote }}
+      OPTIONS: {{- include "common.tplvalues.render" (dict "value" .Values.externalDatabase.options "context" $) | nindent 8 }}
       CONN_MAX_AGE: {{ .Values.externalDatabase.connMaxAge | int }}
       DISABLE_SERVER_SIDE_CURSORS: {{ toJson .Values.externalDatabase.disableServerSideCursors }}
 

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -394,13 +394,10 @@
         "port": {
           "type": "integer"
         },
-        "sslMode": {
-          "type": "string"
+        "options": {
+          "type": "object"
         },
         "sslRootCert": {
-          "type": "string"
-        },
-        "targetSessionAttrs": {
           "type": "string"
         },
         "username": {

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -397,6 +397,9 @@
         "sslMode": {
           "type": "string"
         },
+        "sslRootCert": {
+          "type": "string"
+        },
         "targetSessionAttrs": {
           "type": "string"
         },

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -397,9 +397,6 @@
         "options": {
           "type": "object"
         },
-        "sslRootCert": {
-          "type": "string"
-        },
         "username": {
           "type": "string"
         }

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -1028,6 +1028,7 @@ externalDatabase:
 
   # The following settings also apply when using the bundled PostgreSQL chart:
   sslMode: prefer
+  sslRootCert: ""
   connMaxAge: 300
   disableServerSideCursors: false
   targetSessionAttrs: read-write

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -1027,11 +1027,14 @@ externalDatabase:
   existingSecretKey: postgresql-password
 
   # The following settings also apply when using the bundled PostgreSQL chart:
-  sslMode: prefer
-  sslRootCert: ""
   connMaxAge: 300
   disableServerSideCursors: false
-  targetSessionAttrs: read-write
+  ## @param externalDatabase.options Additional PostgreSQL client parameters
+  ## Ref: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
+  ##
+  options:
+    sslmode: "prefer"
+    target_session_attrs: "read-write"
 
 ## Redis chart configuration
 ## https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml


### PR DESCRIPTION
The `sslrootcert` parameter specifies the name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities (in the case of an SSL connection to the PostgreSQL DB).

See the option in the documentation here: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT

Resolves #417 