### PR TITLE
Fix deployment `extraEnvs` template indent

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.165
+version: 5.0.0-beta.166
 appVersion: "v4.1.8"
 type: application
 kubeVersion: ^1.25.0-0

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
               fieldPath: status.podIP
         {{- end }}
         {{- if .Values.extraEnvs }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvs "context" $) | nindent 10 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvs "context" $) | nindent 8 }}
         {{- end }}
         {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
         envFrom:


### PR DESCRIPTION
As title, indent got bumped to 10 in #405 (cdd50ae) and it's one level too many.