### PR TITLE
Improve auth `sso_pipeline_roles` script with Django settings

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.0-beta.172
+version: 5.0.0-beta.173
 appVersion: "v4.1.8"
 type: application
 kubeVersion: ^1.25.0-0


### PR DESCRIPTION
The current scripts provided for keycloak and gitlab, require the `client_id` to be configured in the script as well as the config values for social auth.

This pull request, adapts the script slightly, to read the `client_id` from django.settings, ensuring that the same value is used, as configured for social auth.

Additionally two more fields are introduced, to make the mapping of staff/superuser roles configurable.