### PR TITLE
Fix LDAP values types

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.7
+version: 5.0.8
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.1.10"
 type: application

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -1057,10 +1057,10 @@
               "type": "boolean"
             },
             "mirrorGroups": {
-              "type": "boolean"
+              "type": ["boolean", "string", "array"]
             },
             "mirrorGroupsExcept": {
-              "type": "array"
+              "type": ["null", "string", "array"]
             },
             "cacheTimeout": {
               "type": "integer"

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -1060,7 +1060,7 @@
               "type": "boolean"
             },
             "mirrorGroupsExcept": {
-              "type": "string"
+              "type": "array"
             },
             "cacheTimeout": {
               "type": "integer"

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -402,7 +402,7 @@ remoteAuth:
       - CN=Domain Admins,CN=Users,DC=example,dc=com
     findGroupPerms: true
     mirrorGroups: true
-    mirrorGroupsExcept: ""
+    mirrorGroupsExcept: []
     cacheTimeout: 3600
     attrFirstName: givenName
     attrLastName: sn


### PR DESCRIPTION
This fixes an error likely introduced in 04c18cd which prevents configuring a working LDAP setup with this chart.
Currently the chart forces `mirrorGroupsExcept` to be a string which results in Netbox throwing the following error when trying to log in:
```
<class 'django.core.exceptions.ImproperlyConfigured'>

AUTH_LDAP_MIRROR_GROUPS_EXCEPT must be a collection of group names
```
With the proposed change, the correct type is set in the schema and a sensible default in the `values.yaml` is added.