### PR TITLE
Add support for `LDAP_CA_CERT_DIR`

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.13
+version: 5.0.14
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.2.1"
 type: application

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -155,6 +155,7 @@ The following table lists the configurable parameters for this chart and their d
 | `remoteAuth.ldap.serverUri`                     | see [django-auth-ldap](https://django-auth-ldap.readthedocs.io)     | `""`                                         |
 | `remoteAuth.ldap.startTls`                      | if StarTLS should be used                                           | *see values.yaml*                            |
 | `remoteAuth.ldap.ignoreCertErrors`              | if Certificate errors should be ignored                             | *see values.yaml*                            |
+| `remoteAuth.ldap.caCertDir`                     | CA certificate directory                                            | *see auth.md*                                |
 | `remoteAuth.ldap.caCertData`                    | CA certificate data                                                 | *see auth.md*                                |
 | `remoteAuth.ldap.bindDn`                        | Distinguished Name to bind with                                     | `""`                                         |
 | `remoteAuth.ldap.bindPassword`                  | Password for bind DN                                                | `""`                                         |

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -170,6 +170,9 @@ data:
     AUTH_LDAP_BIND_DN: {{ .Values.remoteAuth.ldap.bindDn | quote }}
     AUTH_LDAP_START_TLS: {{ toJson .Values.remoteAuth.ldap.startTls }}
     LDAP_IGNORE_CERT_ERRORS: {{ toJson .Values.remoteAuth.ldap.ignoreCertErrors }}
+    {{- if .Values.remoteAuth.ldap.caCertDir }}
+    LDAP_CA_CERT_DIR: {{ .Values.remoteAuth.ldap.caCertDir | quote }}
+    {{- end }}
     {{- if .Values.remoteAuth.ldap.caCertData }}
     LDAP_CA_CERT_FILE: /etc/netbox/config/ldap/ldap_ca.crt
     {{- end }}

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -1008,6 +1008,9 @@
             "ignoreCertErrors": {
               "type": "boolean"
             },
+            "caCertDir": {
+              "type": "string"
+            },
             "caCertData": {
               "type": "string"
             },

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -384,6 +384,7 @@ remoteAuth:
     serverUri: ldap://example.com
     startTls: true
     ignoreCertErrors: false
+    caCertDir: ""
     caCertData: ""
     bindDn: CN=Netbox,OU=EmbeddedDevices,OU=MyCompany,DC=example,dc=com
     bindPassword: ""

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -238,11 +238,11 @@ remoteAuth:
     # and ALL the other remoteAuth.ldap.* settings from values.yaml
 ```
 
+> [!NOTE]
+> In order to use anonymous LDAP binding, set `bindDn` and `bindPassword`
+> to an empty string as in the example above.
+
 ### LDAP Certificate Verification
-
-Note: in order to use anonymous LDAP binding set `bindDn` and `bindPassword`
-to an empty string as in the example above.
-
 If you need to specify your own CA certificate, follow the instructions below.
 
 Option 1. In your `values.yaml` file define the directory already containing your CA certificate:

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -238,12 +238,24 @@ remoteAuth:
     # and ALL the other remoteAuth.ldap.* settings from values.yaml
 ```
 
+### LDAP Certificate Verification
+
 Note: in order to use anonymous LDAP binding set `bindDn` and `bindPassword`
 to an empty string as in the example above.
 
 If you need to specify your own CA certificate, follow the instructions below.
 
-In your `values.yaml` file define your CA certificate content in `caCertData`:
+Option 1. In your `values.yaml` file define the directory already containing your CA certificate:
+
+```yaml
+  ldap:
+    serverUri: 'ldap://domain.com'
+    startTls: true
+    ignoreCertErrors: false
+    caCertDir: /etc/ssl/certs
+```
+
+Option 2. In your `values.yaml` file define your CA certificate content in `caCertData`:
 
 ```yaml
   ldap:


### PR DESCRIPTION
Add support for missing LDAP configuration option [LDAP_CA_CERT_DIR](https://github.com/netbox-community/netbox/issues/9722)