### PR TITLE
Allow for manual mounting of secrets

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.55
+version: 5.0.56
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.2.6"
 type: application

--- a/charts/netbox/files/configuration.py
+++ b/charts/netbox/files/configuration.py
@@ -57,11 +57,13 @@ REDIS = {}
 
 _load_yaml()
 
-DATABASE["PASSWORD"] = _read_secret("netbox", "db_password")
-EMAIL["PASSWORD"] = _read_secret("netbox", "email_password")
-REDIS["tasks"]["PASSWORD"] = _read_secret("netbox", "redis_tasks_password")
-REDIS["caching"]["PASSWORD"] = _read_secret("netbox", "redis_cache_password")
-SECRET_KEY = _read_secret("netbox", "secret_key")
+provided_secret_name = os.getenv("SECRET_NAME", "netbox")
+
+DATABASE["PASSWORD"] = _read_secret(provided_secret_name, "db_password")
+EMAIL["PASSWORD"] = _read_secret(provided_secret_name, "email_password")
+REDIS["tasks"]["PASSWORD"] = _read_secret(provided_secret_name, "redis_tasks_password")
+REDIS["caching"]["PASSWORD"] = _read_secret(provided_secret_name, "redis_cache_password")
+SECRET_KEY = _read_secret(provided_secret_name, "secret_key")
 
 # Post-process certain values
 CORS_ORIGIN_REGEX_WHITELIST = [re.compile(r) for r in CORS_ORIGIN_REGEX_WHITELIST]


### PR DESCRIPTION
This PR adds a new value `customSecretMount` which is false by default. If `customSecretMount: true` is set, volumeMounts and volumes regarding secrets are excluded from the generated templates. Leaving it up to the user to define extraVolumes and extraVolumeMounts to define secrets.

# Use case
This feature is needed when the chart user defines custom volumes for secrets (ex. when using [Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/)) instead of relying on kubernetes secrets or environment variables.

# Additions
The definition of volumes and volumeMounts regarding `/run/secrets/` have been moved into a `{{- if (eq .Values.customSecretMount false) }}` block.

# Notes
`customSecretMount` could also be changed to a variable name like `usePasswordFiles` similar to the [postgresql chart implementation](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml#L178)

It could be beneficial to split up the `customSecretMount` option for the main process, worker and housekeeper, similar to the separated definitions of `extraVolumes` and `extraVolumeMounts`.