### PR TITLE
Set `enforceGlobalUnique` default to `true`

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.50
+version: 5.0.51
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.2.5"
 type: application

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -108,7 +108,7 @@ The following table lists the configurable parameters for this chart and their d
 | `email.sslKeyFile`                              | SMTP SSL key file path (e.g. in a mounted volume)                   | `""`                                         |
 | `email.timeout`                                 | Timeout for SMTP connections, in seconds                            | `10`                                         |
 | `email.from`                                    | Sender address for emails sent by NetBox                            | `""`                                         |
-| `enforceGlobalUnique`                           | Enforce unique IP space in the global table (not in a VRF)          | `false`                                      |
+| `enforceGlobalUnique`                           | Enforce unique IP space in the global table (not in a VRF)          | `true`                                      |
 | `exemptViewPermissions`                         | A list of models to exempt from the enforcement of view permissions | `[]`                                         |
 | `fieldChoices`                                  | Configure custom choices for certain built-in fields                | `{}`                                         |
 | `fileUploadMaxMemorySize`                       | The maximum amount (in bytes) of uploaded data that will be held in memory before being written to the filesystem  | `2621440` |

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -228,7 +228,7 @@ email:
 # Enforcement of unique IP space can be toggled on a per-VRF basis. To enforce
 # unique IP space within the global table (all prefixes and IP addresses not
 # assigned to a VRF), set enforceGlobalUnique to True.
-enforceGlobalUnique: false
+enforceGlobalUnique: true
 
 # Exempt certain models from the enforcement of view permissions. Models listed
 # here will be viewable by all users and by anonymous users. List models in the


### PR DESCRIPTION
'enforceGlobalUnique' default behavior changed from 'false' to 'true' in Netbox 3.7.0 (See https://github.com/netbox-community/netbox/issues/14536).  This PR updates the Helm chart default values to reflect this change in behavior.