### PR TITLE
add missing resources for Operator Cluster Role

### DIFF
--- a/charts/netbox-operator/templates/clusterrole.yaml
+++ b/charts/netbox-operator/templates/clusterrole.yaml
@@ -69,6 +69,31 @@ rules:
   - apiGroups:
       - netbox.dev
     resources:
+      - ipranges
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - netbox.dev
+    resources:
+      - iprangeclaims
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      
+  - apiGroups:
+      - netbox.dev
+    resources:
       - prefixclaims
     verbs:
       - create


### PR DESCRIPTION
Hi,

I think currently 2 Resources are missing at the Operator Cluster Role. 

Without extra Permissions for `ipranges.netbox.dev` and `iprangeclaims.netbox.dev` it was not possible to start the Operator deployment. 