### PR TITLE
Custom apiVersion for serviceMonitor

### DIFF
--- a/charts/netbox-operator/templates/servicemonitor.yaml
+++ b/charts/netbox-operator/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ .Values.metrics.serviceMonitor.apiVersion | default "monitoring.coreos.com/v1" }}
 kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}

--- a/charts/netbox-operator/values.yaml
+++ b/charts/netbox-operator/values.yaml
@@ -334,6 +334,9 @@ metrics:
     ## @param metrics.serviceMonitor.enabled if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
     ##
     enabled: false
+    ## @param metrics.serviceMonitor.apiVersion Custom API version for ServiceMonitor
+    ## e.g:
+    ## apiVersion: monitoring.coreos.com/v1
     ## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
     ##
     honorLabels: false

--- a/charts/netbox/templates/servicemonitor.yaml
+++ b/charts/netbox/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ .Values.metrics.serviceMonitor.apiVersion | default "monitoring.coreos.com/v1" }}
 kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -967,6 +967,9 @@ metrics:
     ## @param metrics.serviceMonitor.enabled if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
     ##
     enabled: false
+    ## @param metrics.serviceMonitor.apiVersion Custom API version for ServiceMonitor
+    ## e.g:
+    ## apiVersion: monitoring.coreos.com/v1
     ## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
     ##
     honorLabels: false


### PR DESCRIPTION
Some cloud providers implement ServiceMonitor using their own CRDs, which differ from the default "monitoring.coreos.com/v1". 

E.g., Azure Monitor uses "azmonitoring.coreos.com/v1" for ServiceMonitor resources.

https://learn.microsoft.com/en-us/azure/azure-monitor/containers/prometheus-metrics-scrape-configuration?tabs=CRDConfig%2CCRDScrapeConfig%2CConfigFileScrapeConfigBasicAuth%2CConfigFileScrapeConfigTLSAuth

This PR introduces a variable to override the default apiVersion when generating ServiceMonitor object. We keep "monitoring.coreos.com/v1" as default
