### PR TITLE
[v6] Prevent failures and restarts of deployments

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.77
+version: 6.0.0
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.3.0"
 type: application

--- a/charts/netbox/templates/role.yaml
+++ b/charts/netbox/templates/role.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  {{- if and .Values.worker.enabled .Values.worker.waitForBackend.enabled }}
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  {{- end }}
+  {{- if .Values.rbac.rules }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.rbac.rules "context" $ ) | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/netbox/templates/rolebinding.yaml
+++ b/charts/netbox/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+roleRef:
+  kind: Role
+  name: {{ include "common.names.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "netbox.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}
+{{- end }}

--- a/charts/netbox/templates/worker/deployment.yaml
+++ b/charts/netbox/templates/worker/deployment.yaml
@@ -39,8 +39,33 @@ spec:
       {{- if .Values.worker.podSecurityContext.enabled }}
       securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.worker.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.worker.initContainers }}
-      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.worker.initContainers "context" $) | trim | nindent 8 }}
+      {{- if or .Values.worker.initContainers .Values.worker.waitForBackend.enabled }}
+      initContainers:
+        {{- if .Values.worker.waitForBackend.enabled }}
+        - name: wait-for-backend
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.worker.waitForBackend.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.worker.waitForBackend.image.pullPolicy | quote }}
+          {{- if .Values.worker.waitForBackend.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.worker.waitForBackend.command "context" $) | nindent 10 }}
+          {{- end }}
+          {{- if .Values.worker.waitForBackend.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.worker.waitForBackend.args "context" $) | nindent 10 }}
+          {{- end }}
+          {{- if .Values.worker.waitForBackend.containerSecurityContext.enabled }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.worker.waitForBackend.containerSecurityContext "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.worker.waitForBackend.resources }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.worker.waitForBackend.resources "context" $) | nindent 12 }}
+          {{- else if ne .Values.worker.waitForBackend.resourcesPreset "none" }}
+          resources: {{- include "common.resources.preset" (dict "type" .Values.worker.waitForBackend.resourcesPreset) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: DEPLOYMENT_NAME
+              value: {{ include "common.names.fullname" . }}
+        {{- end }}
+        {{- if .Values.worker.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.worker.initContainers "context" $) | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-worker

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -917,6 +917,17 @@
     "rackElevationDefaultUnitWidth": {
       "type": "integer"
     },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "rules": {
+          "type": "array"
+        }
+      }
+    },
     "readinessProbe": {
       "$ref": "#/$defs/probe"
     },
@@ -1622,6 +1633,99 @@
           "properties": {
             "type": {
               "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "waitForBackend": {
+          "properties": {
+            "args": {
+              "type": "array"
+            },
+            "command": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "podSecurityContext": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "fsGroup": {
+                  "type": "integer"
+                },
+                "fsGroupChangePolicy": {
+                  "type": "string"
+                },
+                "supplementalGroups": {
+                  "type": "array"
+                },
+                "sysctls": {
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "resources": {
+              "properties": {},
+              "type": "object"
+            },
+            "resourcesPreset": {
+              "type": "string"
+            },
+            "securityContext": {
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "type": "boolean"
+                },
+                "capabilities": {
+                  "properties": {
+                    "drop": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "privileged": {
+                  "type": "boolean"
+                },
+                "readOnlyRootFilesystem": {
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "seccompProfile": {
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
             }
           },
           "type": "object"

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -834,7 +834,7 @@ startupProbe:
   initialDelaySeconds: 5
   periodSeconds: 10
   timeoutSeconds: 1
-  failureThreshold: 10
+  failureThreshold: 100
   successThreshold: 1
 ## @param customLivenessProbe Override default liveness probe for containers
 ##

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -632,6 +632,25 @@ serviceAccount:
   annotations: {}
   name: ""
   automountServiceAccountToken: false
+## Role Based Access
+## ref: https://kubernetes.io/docs/admin/authorization/rbac/
+##
+rbac:
+  ## @param rbac.create Specifies whether RBAC resources should be created
+  ##
+  create: true
+  ## @param rbac.rules Custom RBAC rules to set
+  ## e.g:
+  ## rules:
+  ##   - apiGroups:
+  ##       - ""
+  ##     resources:
+  ##       - pods
+  ##     verbs:
+  ##       - get
+  ##       - list
+  ##
+  rules: []
 ## @param hostAliases [array] Add deployment host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
@@ -1511,7 +1530,7 @@ worker:
   readOnlyPersistence: false
   ## @param worker.automountServiceAccountToken Mount Service Account token in pod
   ##
-  automountServiceAccountToken: false
+  automountServiceAccountToken: true
   ## @param worker.affinity Affinity for worker pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
@@ -1634,3 +1653,96 @@ worker:
   ##    command: ['sh', '-c', 'echo "init"']
   ##
   initContainers: []
+  ## Init containers parameters:
+  ## wait-for-backend: Wait for NetBox backend before running workers
+  ##
+  waitForBackend:
+    ## @param waitForBackend.enabled Wait for NetBox backend before running workers
+    ##
+    enabled: true
+    ## @param waitForBackend.image.registry [default: REGISTRY_NAME] Init container wait-for-backend image registry
+    ## @param waitForBackend.image.repository [default: REPOSITORY_NAME/kubectl] Init container wait-for-backend image name
+    ## @param waitForBackend.image.tag Init container wait-for-backend image tag
+    ## @param waitForBackend.image.digest Init container wait-for-backend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+    ## @param waitForBackend.image.pullPolicy Init container wait-for-backend image pull policy
+    ## @param waitForBackend.image.pullSecrets Specify docker-registry secret names as an array
+    ##
+    image:
+      registry: docker.io
+      repository: bitnami/kubectl
+      tag: 1.32.2-debian-12-r3
+      digest: ""
+      ## Specify a imagePullPolicy
+      ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## Example:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+    ## @param waitForBackend.command The command to execute in the wait-for-backend container
+    ##
+    command:
+      - /bin/bash
+      - -ec
+    ## @param waitForBackend.args Override wait-for-backend container args
+    ##
+    args:
+      - |
+        deployment=${DEPLOYMENT_NAME:?deployment name is missing}
+        return_code=0
+
+        echo "Waiting for deployment \"${deployment}\" to be successfully rolled out..."
+        kubectl rollout status deployment "$deployment" 2>&1 || return_code=$?
+        echo "Rollout exit code: '${return_code}'"
+        exit $return_code
+    ## waitForBackend containers' Security Context (init container).
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+    ## @param waitForBackend.containerSecurityContext.enabled Enabled containers' Security Context
+    ## @param waitForBackend.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
+    ## @param waitForBackend.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+    ## @param waitForBackend.containerSecurityContext.runAsGroup Set containers' Security Context runAsGroup
+    ## @param waitForBackend.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+    ## @param waitForBackend.containerSecurityContext.privileged Set container's Security Context privileged
+    ## @param waitForBackend.containerSecurityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+    ## @param waitForBackend.containerSecurityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+    ## @param waitForBackend.containerSecurityContext.capabilities.drop List of capabilities to be dropped
+    ## @param waitForBackend.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
+    ##
+    containerSecurityContext:
+      enabled: true
+      seLinuxOptions: {}
+      runAsUser: 1001
+      runAsGroup: 1001
+      runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"
+    ## Init container resource requests and limits.
+    ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    ## We usually recommend not to specify default resources and to leave this as a conscious
+    ## choice for the user. This also increases chances charts run on environments with little
+    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## @param waitForBackend.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if waitForBackend.resources is set (waitForBackend.resources is recommended for production).
+    ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+    ##
+    resourcesPreset: "nano"
+    ## @param waitForBackend.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+    ## Example:
+    ## resources:
+    ##   requests:
+    ##     cpu: 2
+    ##     memory: 512Mi
+    ##   limits:
+    ##     cpu: 3
+    ##     memory: 1024Mi
+    ##
+    resources: {}


### PR DESCRIPTION
> [!note]
> Kinda big feature and bring a additionnal container image to the chart, thus bumping minor version.

1. Increase startup probe failure threshold
2. Add an initial container to the worker deployment so it waits for main deployment to be ready before spinning in.

Fixes #581