### PR TITLE
Add volume placeholders for operator deployment

### DIFF
--- a/charts/netbox-operator/Chart.yaml
+++ b/charts/netbox-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox-operator
-version: 0.3.21
+version: 0.4.0
 # renovate: image=ghcr.io/netbox-community/netbox-operator
 appVersion: "v0.1.0-alpha.6"
 type: application

--- a/charts/netbox-operator/templates/deployment.yaml
+++ b/charts/netbox-operator/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - name: DEBUG_ENABLE
               value: {{ .Values.debug | quote }}
             - name: CA_CERT
-              value: {{ .Values.caCert | quote }}
+              value: {{ .Values.caCertPath | quote }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
@@ -106,11 +106,17 @@ spec:
               path: /readyz
               port: http-probe
           {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts: {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- else if ne .Values.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.resourcesPreset) | nindent 12 }}
           {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes: {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
       {{- end }}

--- a/charts/netbox-operator/values.yaml
+++ b/charts/netbox-operator/values.yaml
@@ -82,7 +82,8 @@ image:
 ## @section NetBox Operator Configuration parameters
 
 ## NetBox Operator settings based on environment variables
-caCert: ""
+# When defining caCertPath, make sure you mount the secret containing the CA certificate on all the necessary containers
+caCertPath: ""
 host: ""
 https: false
 restorationHashFieldName: ""
@@ -136,6 +137,23 @@ serviceAccount:
   annotations: {}
   name: ""
   automountServiceAccountToken: true
+## @param extraVolumes Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`
+## e.g:
+## extraVolumes:
+##   - name: ca-cert
+##     secret:
+##       secretName: ca-cert
+##
+extraVolumes: []
+## @param extraVolumeMounts Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.
+## e.g:
+## extraVolumeMounts:
+##   - name: ca-cert
+##     mountPath: /tmp/ca.cert
+##     subPath: ca-cert
+##     readOnly: true
+##
+extraVolumeMounts: []
 ## @param sidecars Add additional sidecar containers to the pod
 ## e.g:
 ## sidecars:


### PR DESCRIPTION
Fixes #602
Also clarify `caCert` value by renaming it `caCertPath`.