### PR TITLE
Leverage Renovate new `bumpVersions` option

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,14 @@
     {
       "matchUpdateTypes": ["!major"],
       "automerge": true
+    },
+    {
+      "matchFileNames": ["charts/**"],
+      "bumpVersions": {
+        "filePatterns": "{{packageFileDir}}/Chart.{yaml,yml}",
+        "matchStrings": ["version:\\s(?<version>[^\\s]+)"],
+        "bumpType": "{{#if isMajor}}minor{{else}}patch{{/if}}"
+      }
     }
   ],
   "kubernetes": {


### PR DESCRIPTION
Should fix the lack of version bumps when the change is a Docker image.
Ref: https://github.com/renovatebot/renovate/pull/34023

> [!note]
> Keept as a draft untile version Renovate 40.5.0+ is used on the hosted platform.