### PR TITLE
Release v6.0.0

### DIFF
--- a/charts/netbox/Chart.lock
+++ b/charts/netbox/Chart.lock
@@ -5,8 +5,8 @@ dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 16.6.7
-- name: redis
+- name: valkey
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.13.4
-digest: sha256:c85b0a68237e3543ad5f6c84016e54937e00fc146630025bf93a6f324e12c304
-generated: "2025-05-06T19:42:20.150295683Z"
+  version: 3.0.4
+digest: sha256:3e87b1d3d94c8cff1c5c90d1a714b9de156ae00da28c4dcf0cea8815c073b5c9
+generated: "2025-05-06T21:14:01.568709526Z"

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 5.0.78
+version: 6.0.0
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.3.0"
 type: application

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -26,10 +26,10 @@ dependencies:
     version: ^16.6.7
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
-  - name: redis
-    version: ^20.13.4
+  - name: valkey
+    version: ^3.0.4
     repository: oci://registry-1.docker.io/bitnamicharts
-    condition: redis.enabled
+    condition: valkey.enabled
 annotations:
   artifacthub.io/images: |
     - name: netbox

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: netbox
 version: 5.0.78
 # renovate: image=ghcr.io/netbox-community/netbox
-appVersion: "v4.2.9"
+appVersion: "v4.3.0"
 type: application
 kubeVersion: ^1.25.0-0
 description: IP address management (IPAM) and data center infrastructure management (DCIM) tool
@@ -33,7 +33,7 @@ dependencies:
 annotations:
   artifacthub.io/images: |
     - name: netbox
-      image: ghcr.io/netbox-community/netbox:v4.2.9
+      image: ghcr.io/netbox-community/netbox:v4.3.0
     - name: busybox
       image: docker.io/busybox:1.37.0
   artifacthub.io/license: Apache-2.0

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -27,7 +27,7 @@ helm install my-release oci://ghcr.io/netbox-community/netbox-chart/netbox
 
 ### Production Usage
 
-We recommend using separate external PostgreSQL and Redis instances. This
+We recommend using separate external PostgreSQL and Key-Value instances. This
 de-couples those services from the chart's bundled versions which may have
 complex upgrade requirements. A clustered PostgreSQL server (e.g. using Zalando's
 [Postgres Operator](https://github.com/zalando/postgres-operator)) and Redis
@@ -210,35 +210,35 @@ The following table lists the configurable parameters for this chart and their d
 | `externalDatabase.existingSecretKey`            | Key to fetch the password in the above `Secret`                     | `postgresql-password`                        |
 | `externalDatabase.connMaxAge`                   | The lifetime of a database connection, as an integer of seconds     | `300`                                        |
 | `externalDatabase.disableServerSideCursors`     | Disable the use of server-side cursors transaction pooling          | `false`                                      |
-| `externalDatabase.options`                      | Additional PostgreSQL client parameters             | `{}`                                            |
-| `redis.enabled`                                 | Deploy Redis using bundled Bitnami Redis chart                      | `true`                                       |
-| `redis.*`                                       | Values under this key are passed to the bundled Redis chart         | n/a                                          |
-| `tasksRedis.database`                           | Redis database number used for NetBox task queue                    | `0`                                          |
-| `tasksRedis.ssl`                                | Enable SSL when connecting to Redis                                 | `false`                                      |
-| `tasksRedis.insecureSkipTlsVerify`              | Skip TLS certificate verification when connecting to Redis          | `false`                                      |
-| `tasksRedis.caCertPath`                         | Path to CA certificates bundle for Redis (needs mounting manually)  | `""`                                         |
-| `tasksRedis.host`                               | Redis host to use when `redis.enabled` is `false`                   | `"netbox-redis"`                             |
-| `tasksRedis.port`                               | Port number for external Redis                                      | `6379`                                       |
-| `tasksRedis.sentinels`                          | List of sentinels in `host:port` form (`host` and `port` not used)  | `[]`                                         |
-| `tasksRedis.sentinelService`                    | Sentinel master service name                                        | `"netbox-redis"`                             |
-| `tasksRedis.sentinelTimeout`                    | Sentinel connection timeout, in seconds                             | `300` (5 minutes)                            |
-| `tasksRedis.username`                           | Username for external Redis                                         | `""`                                         |
-| `tasksRedis.password`                           | Password for external Redis (see also `existingSecret`)             | `""`                                         |
-| `tasksRedis.existingSecretName`                 | Fetch password for external Redis from a different `Secret`         | `""`                                         |
-| `tasksRedis.existingSecretKey`                  | Key to fetch the password in the above `Secret`                     | `redis-password`                             |
-| `cachingRedis.database`                         | Redis database number used for caching views                        | `1`                                          |
-| `cachingRedis.ssl`                              | Enable SSL when connecting to Redis                                 | `false`                                      |
-| `cachingRedis.insecureSkipTlsVerify`            | Skip TLS certificate verification when connecting to Redis          | `false`                                      |
-| `cachingRedis.caCertPath`                       | Path to CA certificates bundle for Redis (needs mounting manually)  | `""`                                         |
-| `cachingRedis.host`                             | Redis host to use when `redis.enabled` is `false`                   | `"netbox-redis"`                             |
-| `cachingRedis.port`                             | Port number for external Redis                                      | `6379`                                       |
-| `cachingRedis.sentinels`                        | List of sentinels in `host:port` form (`host` and `port` not used)  | `[]`                                         |
-| `cachingRedis.sentinelService`                  | Sentinel master service name                                        | `"netbox-redis"`                             |
-| `cachingRedis.sentinelTimeout`                  | Sentinel connection timeout, in seconds                             | `300` (5 minutes)                            |
-| `cachingRedis.username`                         | Username for external Redis                                         | `""`                                         |
-| `cachingRedis.password`                         | Password for external Redis (see also `existingSecret`)             | `""`                                         |
-| `cachingRedis.existingSecretName`               | Fetch password for external Redis from a different `Secret`         | `""`                                         |
-| `cachingRedis.existingSecretKey`                | Key to fetch the password in the above `Secret`                     | `redis-password`                             |
+| `externalDatabase.options`                      | Additional PostgreSQL client parameters                             | `{}`                                            |
+| `valkey.enabled`                                | Deploy Valkey using bundled Bitnami Valkey chart                    | `true`                                       |
+| `valkey.*`                                      | Values under this key are passed to the bundled Valkey chart        | n/a                                          |
+| `tasksDatabase.database`                           | KV database number used for NetBox task queue                       | `0`                                          |
+| `tasksDatabase.ssl`                                | Enable SSL when connecting to KV                                    | `false`                                      |
+| `tasksDatabase.insecureSkipTlsVerify`              | Skip TLS certificate verification when connecting to KV             | `false`                                      |
+| `tasksDatabase.caCertPath`                         | Path to CA certificates bundle for KV (needs mounting manually)     | `""`                                         |
+| `tasksDatabase.host`                               | KV host to use when `valkey.enabled` is `false`                     | `"netbox-kv"`                             |
+| `tasksDatabase.port`                               | Port number for external KV                                         | `6379`                                       |
+| `tasksDatabase.sentinels`                          | List of sentinels in `host:port` form (`host` and `port` not used)  | `[]`                                         |
+| `tasksDatabase.sentinelService`                    | Sentinel master service name                                        | `"netbox-kv"`                             |
+| `tasksDatabase.sentinelTimeout`                    | Sentinel connection timeout, in seconds                             | `300` (5 minutes)                            |
+| `tasksDatabase.username`                           | Username for external KV                                            | `""`                                         |
+| `tasksDatabase.password`                           | Password for external KV (see also `existingSecret`)                | `""`                                         |
+| `tasksDatabase.existingSecretName`                 | Fetch password for external KV from a different `Secret`            | `""`                                         |
+| `tasksDatabase.existingSecretKey`                  | Key to fetch the password in the above `Secret`                     | `tasks-password`                             |
+| `cachingDatabase.database`                         | KV database number used for caching views                           | `1`                                          |
+| `cachingDatabase.ssl`                              | Enable SSL when connecting to KV                                    | `false`                                      |
+| `cachingDatabase.insecureSkipTlsVerify`            | Skip TLS certificate verification when connecting to KV             | `false`                                      |
+| `cachingDatabase.caCertPath`                       | Path to CA certificates bundle for KV (needs mounting manually)     | `""`                                         |
+| `cachingDatabase.host`                             | KV host to use when `valkey.enabled` is `false`                     | `"netbox-kv"`                             |
+| `cachingDatabase.port`                             | Port number for external KV                                         | `6379`                                       |
+| `cachingDatabase.sentinels`                        | List of sentinels in `host:port` form (`host` and `port` not used)  | `[]`                                         |
+| `cachingDatabase.sentinelService`                  | Sentinel master service name                                        | `"netbox-kv"`                             |
+| `cachingDatabase.sentinelTimeout`                  | Sentinel connection timeout, in seconds                             | `300` (5 minutes)                            |
+| `cachingDatabase.username`                         | Username for external KV                                            | `""`                                         |
+| `cachingDatabase.password`                         | Password for external KV (see also `existingSecret`)                | `""`                                         |
+| `cachingDatabase.existingSecretName`               | Fetch password for external KV from a different `Secret`            | `""`                                         |
+| `cachingDatabase.existingSecretKey`                | Key to fetch the password in the above `Secret`                     | `cache-password`                             |
 | `imagePullSecrets`                              | List of `Secret` names containing private registry credentials      | `[]`                                         |
 | `nameOverride`                                  | Override the application name (`netbox`) used throughout the chart  | `""`                                         |
 | `fullnameOverride`                              | Override the full name of resources created as part of the release  | `""`                                         |
@@ -470,11 +470,17 @@ Type: `kubernetes.io/basic-auth`
 | --------------------- | ------------------------------------------------- | ---------------------------------- |
 | `postgresql-password` | The password for the external PostgreSQL database | If `postgresql.enabled` is `false` |
 
-### Redis secrets (`tasksRedis.existingSecretName` & `cachingRedis.existingSecretName`)
+### Tasks secrets (`tasksDatabase.existingSecretName`)
 
 | Key              | Description                                                   | Required?                     |
 | ---------------- | ------------------------------------------------------------- | ----------------------------- |
-| `redis-password` | Password for the external Redis database (tasks and/or cache) | If `redis.enabled` is `false` |
+| `tasks-password` | Password for the external KV database (tasks and/or cache)    | If `valkey.enabled` is `false` |
+
+### Cache secrets (`cachingDatabase.existingSecretName`)
+
+| Key              | Description                                                   | Required?                     |
+| ---------------- | ------------------------------------------------------------- | ----------------------------- |
+| `cache-password` | Password for the external KV database (tasks and/or cache)    | If `valkey.enabled` is `false` |
 
 ## Authentication
 

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -34,7 +34,7 @@ complex upgrade requirements. A clustered PostgreSQL server (e.g. using Zalando'
 with Sentinel (e.g. using [Aaron Layfield](https://github.com/DandyDeveloper)'s
 [redis-ha chart](https://github.com/DandyDeveloper/charts/tree/master/charts/redis-ha)).
 
-Set `persistence.enabled` to `false` and use the S3 `storageBackend` and `storageConfig`
+Set `persistence.enabled` to `false` and use the S3 `storages`
 for object storage. This works well with Minio or Ceph RGW as well as Amazon S3.
 See [Persistent storage pitfalls](#persistent-storage-pitfalls), below.
 
@@ -124,8 +124,7 @@ The following table lists the configurable parameters for this chart and their d
 | `maintenanceMode`                               | Display a "maintenance mode" banner on every page                   | `false`                                      |
 | `mapsUrl`                                       | The URL to use when mapping physical addresses or GPS coordinates   | `https://maps.google.com/?q=`                |
 | `maxPageSize`                                   | Maximum number of objects that can be returned by a single API call | `1000`                                       |
-| `storageBackend`                                | Django-storages backend class name                                  | `null`                                       |
-| `storageConfig`                                 | Django-storages backend configuration                               | `{}`                                         |
+| `storages`                                      | `django-storages` backends configuration                            | `{}`                                         |
 | `paginateCount`                                 | The default number of objects to display per page in the web UI     | `50`                                         |
 | `plugins`                                       | Additional plugins to load into NetBox                              | `[]`                                         |
 | `pluginsConfig`                                 | Configuration for the additional plugins                            | `{}`                                         |
@@ -390,7 +389,7 @@ this problem:
 
 <!-- prettier-ignore-start -->
 
-1. Use the recommended S3 `storageBackend` and **disable** persistent storage
+1. Use the recommended S3 `storages` and **disable** persistent storage
     by setting `persistence.enabled` to `false`. This can
     be used with any S3-compatible storage provider including Amazon S3, Minio,
     Ceph RGW, and many others. See further down for an example of this.

--- a/charts/netbox/files/configuration.py
+++ b/charts/netbox/files/configuration.py
@@ -51,7 +51,7 @@ def _read_secret(secret_name: str, secret_key: str, default: str | None = None) 
 
 
 CORS_ORIGIN_REGEX_WHITELIST = []
-DATABASE = {}
+DATABASES = {}
 EMAIL = {}
 REDIS = {}
 
@@ -59,7 +59,7 @@ _load_yaml()
 
 provided_secret_name = os.getenv("SECRET_NAME", "netbox")
 
-DATABASE["PASSWORD"] = _read_secret(provided_secret_name, "db_password")
+DATABASES["default"]["PASSWORD"] = _read_secret(provided_secret_name, "db_password")
 EMAIL["PASSWORD"] = _read_secret(provided_secret_name, "email_password")
 REDIS["tasks"]["PASSWORD"] = _read_secret(provided_secret_name, "tasks_password")
 REDIS["caching"]["PASSWORD"] = _read_secret(provided_secret_name, "cache_password")

--- a/charts/netbox/files/configuration.py
+++ b/charts/netbox/files/configuration.py
@@ -61,8 +61,8 @@ provided_secret_name = os.getenv("SECRET_NAME", "netbox")
 
 DATABASE["PASSWORD"] = _read_secret(provided_secret_name, "db_password")
 EMAIL["PASSWORD"] = _read_secret(provided_secret_name, "email_password")
-REDIS["tasks"]["PASSWORD"] = _read_secret(provided_secret_name, "redis_tasks_password")
-REDIS["caching"]["PASSWORD"] = _read_secret(provided_secret_name, "redis_cache_password")
+REDIS["tasks"]["PASSWORD"] = _read_secret(provided_secret_name, "tasks_password")
+REDIS["caching"]["PASSWORD"] = _read_secret(provided_secret_name, "cache_password")
 SECRET_KEY = _read_secret(provided_secret_name, "secret_key")
 
 # Post-process certain values

--- a/charts/netbox/templates/_helpers.tpl
+++ b/charts/netbox/templates/_helpers.tpl
@@ -61,50 +61,50 @@ Name of the key in Secret that contains the PostgreSQL password
 {{- end }}
 
 {{/*
-Name of the Secret that contains the Redis tasks password
+Name of the Secret that contains the Valkey tasks password
 */}}
-{{- define "netbox.tasksRedis.secret" -}}
-  {{- if .Values.redis.enabled }}
-    {{- include "redis.secretName" .Subcharts.redis -}}
+{{- define "netbox.tasksDatabase.secret" -}}
+  {{- if .Values.valkey.enabled }}
+    {{- include "valkey.secretName" .Subcharts.valkey -}}
   {{- else }}
-    {{- include "common.secrets.name" (dict "existingSecret" .Values.tasksRedis.existingSecretName "defaultNameSuffix" "redis" "context" $) }}
+    {{- include "common.secrets.name" (dict "existingSecret" .Values.tasksDatabase.existingSecretName "defaultNameSuffix" "kv" "context" $) }}
   {{- end }}
 {{- end }}
 
 {{/*
-Name of the key in Secret that contains the Redis tasks password
+Name of the key in Secret that contains the Valkey tasks password
 */}}
-{{- define "netbox.tasksRedis.secretKey" -}}
-  {{- if .Values.redis.enabled -}}
-    {{- include "redis.secretPasswordKey" .Subcharts.redis -}}
-  {{- else if .Values.tasksRedis.existingSecretName -}}
-    {{ .Values.tasksRedis.existingSecretKey }}
+{{- define "netbox.tasksDatabase.secretKey" -}}
+  {{- if .Values.valkey.enabled -}}
+    {{- include "valkey.secretPasswordKey" .Subcharts.valkey -}}
+  {{- else if .Values.tasksDatabase.existingSecretName -}}
+    {{ .Values.tasksDatabase.existingSecretKey }}
   {{- else -}}
-    redis_tasks_password
+    tasks_password
   {{- end -}}
 {{- end }}
 
 {{/*
-Name of the Secret that contains the Redis cache password
+Name of the Secret that contains the Valkey cache password
 */}}
-{{- define "netbox.cachingRedis.secret" -}}
-  {{- if .Values.redis.enabled }}
-    {{- include "redis.secretName" .Subcharts.redis -}}
+{{- define "netbox.cachingDatabase.secret" -}}
+  {{- if .Values.valkey.enabled }}
+    {{- include "valkey.secretName" .Subcharts.valkey -}}
   {{- else }}
-    {{- include "common.secrets.name" (dict "existingSecret" .Values.cachingRedis.existingSecretName "defaultNameSuffix" "redis" "context" $) }}
+    {{- include "common.secrets.name" (dict "existingSecret" .Values.cachingDatabase.existingSecretName "defaultNameSuffix" "valkey" "context" $) }}
   {{- end }}
 {{- end }}
 
 {{/*
-Name of the key in Secret that contains the Redis cache password
+Name of the key in Secret that contains the Valkey cache password
 */}}
-{{- define "netbox.cachingRedis.secretKey" -}}
-  {{- if .Values.redis.enabled -}}
-    {{- include "redis.secretPasswordKey" .Subcharts.redis -}}
-  {{- else if .Values.cachingRedis.existingSecretName -}}
-    {{ .Values.cachingRedis.existingSecretKey }}
+{{- define "netbox.cachingDatabase.secretKey" -}}
+  {{- if .Values.valkey.enabled -}}
+    {{- include "valkey.secretPasswordKey" .Subcharts.valkey -}}
+  {{- else if .Values.cachingDatabase.existingSecretName -}}
+    {{ .Values.cachingDatabase.existingSecretKey }}
   {{- else -}}
-    redis_cache_password
+    cache_password
   {{- end -}}
 {{- end }}
 

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -78,10 +78,7 @@ data:
     MAPS_URL: {{ .Values.mapsUrl | quote }}
     MAX_PAGE_SIZE: {{ int .Values.maxPageSize }}
     MEDIA_ROOT: /opt/netbox/netbox/media
-    {{- if .Values.storageBackend }}
-    STORAGE_BACKEND: {{ .Values.storageBackend | quote }}
-    STORAGE_CONFIG: {{ toJson .Values.storageConfig }}
-    {{- end }}
+    STORAGES: {{ toJson .Values.storages }}
     METRICS_ENABLED: {{ toJson .Values.metrics.enabled }}
     PAGINATE_COUNT: {{ int .Values.paginateCount }}
     PLUGINS: {{ toJson .Values.plugins }}

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -15,21 +15,34 @@ data:
     ALLOWED_HOSTS: {{ toJson .Values.allowedHosts }}
     ALLOWED_HOSTS_INCLUDES_POD_ID: {{ .Values.allowedHostsIncludesPodIP }}
 
-    DATABASE:
-      {{- if .Values.postgresql.enabled }}
-      HOST: {{ include "postgresql.v1.primary.fullname" .Subcharts.postgresql | quote }}
-      USER: {{ include "postgresql.v1.username" .Subcharts.postgresql | quote }}
-      NAME: {{ include "postgresql.v1.database" .Subcharts.postgresql | quote }}
-      PORT: {{ include "postgresql.v1.service.port" .Subcharts.postgresql | int }}
-      {{- else }}
-      HOST: {{ .Values.externalDatabase.host | quote }}
-      USER: {{ .Values.externalDatabase.username | quote }}
-      NAME: {{ .Values.externalDatabase.database | quote }}
-      PORT: {{ .Values.externalDatabase.port | int }}
+    DATABASES:
+      default:
+        {{- if .Values.postgresql.enabled }}
+        HOST: {{ include "postgresql.v1.primary.fullname" .Subcharts.postgresql | quote }}
+        USER: {{ include "postgresql.v1.username" .Subcharts.postgresql | quote }}
+        NAME: {{ include "postgresql.v1.database" .Subcharts.postgresql | quote }}
+        PORT: {{ include "postgresql.v1.service.port" .Subcharts.postgresql | int }}
+        {{- else }}
+        HOST: {{ .Values.externalDatabase.host | quote }}
+        USER: {{ .Values.externalDatabase.username | quote }}
+        NAME: {{ .Values.externalDatabase.database | quote }}
+        PORT: {{ .Values.externalDatabase.port | int }}
+        {{- end }}
+        ENGINE: {{ .Values.externalDatabase.engine | quote }}
+        OPTIONS: {{- include "common.tplvalues.render" (dict "value" .Values.externalDatabase.options "context" $) | nindent 10 }}
+        CONN_MAX_AGE: {{ .Values.externalDatabase.connMaxAge | int }}
+        DISABLE_SERVER_SIDE_CURSORS: {{ toJson .Values.externalDatabase.disableServerSideCursors }}
+      {{- range $key, $db := .Values.additionalDatabases }}
+      {{ $key }}:
+        ENGINE: {{ $db.engine | quote }}
+        NAME: {{ $db.database | quote }}
+        USER: {{ $db.username | quote }}
+        HOST: {{ $db.host | quote }}
+        PORT: {{ $db.port | int }}
+        CONN_MAX_AGE: {{ $db.connMaxAge | int }}
+        OPTIONS: {{- include "common.tplvalues.render" (dict "value" $db.options "context" $) | nindent 10 }}
+        DISABLE_SERVER_SIDE_CURSORS: {{ toJson $db.disableServerSideCursors }}
       {{- end }}
-      OPTIONS: {{- include "common.tplvalues.render" (dict "value" .Values.externalDatabase.options "context" $) | nindent 8 }}
-      CONN_MAX_AGE: {{ .Values.externalDatabase.connMaxAge | int }}
-      DISABLE_SERVER_SIDE_CURSORS: {{ toJson .Values.externalDatabase.disableServerSideCursors }}
 
     ADMINS: {{ toJson .Values.admins }}
     ALLOW_TOKEN_RETRIEVAL: {{ toJson .Values.allowTokenRetrieval }}

--- a/charts/netbox/templates/configmap.yaml
+++ b/charts/netbox/templates/configmap.yaml
@@ -110,39 +110,39 @@ data:
 
     REDIS:
       tasks:
-        {{- if .Values.redis.enabled }}
-        HOST: {{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) | quote }}
-        PORT: {{ .Values.redis.master.service.ports.redis | int }}
-        {{- else if .Values.tasksRedis.sentinels }}
-        SENTINELS: {{ toJson .Values.tasksRedis.sentinels }}
-        SENTINEL_SERVICE: {{ .Values.tasksRedis.sentinelService | quote }}
-        SENTINEL_TIMEOUT: {{ .Values.tasksRedis.sentinelTimeout | int }}
+        {{- if .Values.valkey.enabled }}
+        HOST: {{ printf "%s-primary" (include "common.names.fullname" .Subcharts.valkey) | quote }}
+        PORT: {{ .Values.valkey.primary.service.ports.valkey | int }}
+        {{- else if .Values.tasksDatabase.sentinels }}
+        SENTINELS: {{ toJson .Values.tasksDatabase.sentinels }}
+        SENTINEL_SERVICE: {{ .Values.tasksDatabase.sentinelService | quote }}
+        SENTINEL_TIMEOUT: {{ .Values.tasksDatabase.sentinelTimeout | int }}
         {{- else }}
-        HOST: {{ .Values.tasksRedis.host | quote }}
-        PORT: {{ .Values.tasksRedis.port | int }}
+        HOST: {{ .Values.tasksDatabase.host | quote }}
+        PORT: {{ .Values.tasksDatabase.port | int }}
         {{- end }}
-        USERNAME: {{ .Values.tasksRedis.username | quote }}
-        DATABASE: {{ int .Values.tasksRedis.database }}
-        SSL: {{ toJson .Values.tasksRedis.ssl }}
-        INSECURE_SKIP_TLS_VERIFY: {{ toJson .Values.tasksRedis.insecureSkipTlsVerify }}
-        CA_CERT_PATH: {{ .Values.tasksRedis.caCertPath | quote }}
+        USERNAME: {{ .Values.tasksDatabase.username | quote }}
+        DATABASE: {{ int .Values.tasksDatabase.database }}
+        SSL: {{ toJson .Values.tasksDatabase.ssl }}
+        INSECURE_SKIP_TLS_VERIFY: {{ toJson .Values.tasksDatabase.insecureSkipTlsVerify }}
+        CA_CERT_PATH: {{ .Values.tasksDatabase.caCertPath | quote }}
       caching:
-        {{- if .Values.redis.enabled }}
-        HOST: {{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) | quote }}
-        PORT: {{ .Values.redis.master.service.ports.redis | int }}
-        {{- else if .Values.cachingRedis.sentinels }}
-        SENTINELS: {{ toJson .Values.cachingRedis.sentinels }}
-        SENTINEL_SERVICE: {{ .Values.cachingRedis.sentinelService | quote }}
-        SENTINEL_TIMEOUT: {{ .Values.cachingRedis.sentinelTimeout | int }}
+        {{- if .Values.valkey.enabled }}
+        HOST: {{ printf "%s-primary" (include "common.names.fullname" .Subcharts.valkey) | quote }}
+        PORT: {{ .Values.valkey.primary.service.ports.valkey | int }}
+        {{- else if .Values.cachingDatabase.sentinels }}
+        SENTINELS: {{ toJson .Values.cachingDatabase.sentinels }}
+        SENTINEL_SERVICE: {{ .Values.cachingDatabase.sentinelService | quote }}
+        SENTINEL_TIMEOUT: {{ .Values.cachingDatabase.sentinelTimeout | int }}
         {{- else }}
-        HOST: {{ .Values.cachingRedis.host | quote }}
-        PORT: {{ .Values.cachingRedis.port | int}}
+        HOST: {{ .Values.cachingDatabase.host | quote }}
+        PORT: {{ .Values.cachingDatabase.port | int}}
         {{- end }}
-        USERNAME: {{ .Values.cachingRedis.username | quote }}
-        DATABASE: {{ int .Values.cachingRedis.database }}
-        SSL: {{ toJson .Values.cachingRedis.ssl }}
-        INSECURE_SKIP_TLS_VERIFY: {{ toJson .Values.cachingRedis.insecureSkipTlsVerify }}
-        CA_CERT_PATH: {{ .Values.cachingRedis.caCertPath | quote }}
+        USERNAME: {{ .Values.cachingDatabase.username | quote }}
+        DATABASE: {{ int .Values.cachingDatabase.database }}
+        SSL: {{ toJson .Values.cachingDatabase.ssl }}
+        INSECURE_SKIP_TLS_VERIFY: {{ toJson .Values.cachingDatabase.insecureSkipTlsVerify }}
+        CA_CERT_PATH: {{ .Values.cachingDatabase.caCertPath | quote }}
 
     REPORTS_ROOT: /opt/netbox/netbox/reports
     RQ_DEFAULT_TIMEOUT: {{ .Values.rqDefaultTimeout | int }}

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -145,15 +145,15 @@ spec:
                   - key: {{ include "netbox.postgresql.secretKey" . | quote }}
                     path: db_password
               - secret:
-                  name: {{ include "netbox.tasksRedis.secret" . | quote }}
+                  name: {{ include "netbox.tasksDatabase.secret" . | quote }}
                   items:
-                  - key: {{ include "netbox.tasksRedis.secretKey" . | quote }}
-                    path: redis_tasks_password
+                  - key: {{ include "netbox.tasksDatabase.secretKey" . | quote }}
+                    path: tasks_password
               - secret:
-                  name: {{ include "netbox.cachingRedis.secret" . | quote }}
+                  name: {{ include "netbox.cachingDatabase.secret" . | quote }}
                   items:
-                  - key: {{ include "netbox.cachingRedis.secretKey" . | quote }}
-                    path: redis_cache_password
+                  - key: {{ include "netbox.cachingDatabase.secretKey" . | quote }}
+                    path: cache_password
           {{- include "netbox.extraConfig.volumes" . | nindent 10 }}
           - name: netbox-tmp
             emptyDir:

--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -248,15 +248,15 @@ spec:
               - key: {{ include "netbox.postgresql.secretKey" . | quote }}
                 path: db_password
           - secret:
-              name: {{ include "netbox.tasksRedis.secret" . | quote }}
+              name: {{ include "netbox.tasksDatabase.secret" . | quote }}
               items:
-              - key: {{ include "netbox.tasksRedis.secretKey" . | quote }}
-                path: redis_tasks_password
+              - key: {{ include "netbox.tasksDatabase.secretKey" . | quote }}
+                path: tasks_password
           - secret:
-              name: {{ include "netbox.cachingRedis.secret" . | quote }}
+              name: {{ include "netbox.cachingDatabase.secret" . | quote }}
               items:
-              - key: {{ include "netbox.cachingRedis.secretKey" . | quote }}
-                path: redis_cache_password
+              - key: {{ include "netbox.cachingDatabase.secretKey" . | quote }}
+                path: cache_password
       {{- include "netbox.extraConfig.volumes" . | nindent 6 }}
       - name: netbox-tmp
         emptyDir:

--- a/charts/netbox/templates/role.yaml
+++ b/charts/netbox/templates/role.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  {{- if and .Values.worker.enabled .Values.worker.waitForBackend.enabled }}
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  {{- end }}
+  {{- if .Values.rbac.rules }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.rbac.rules "context" $ ) | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/netbox/templates/rolebinding.yaml
+++ b/charts/netbox/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+roleRef:
+  kind: Role
+  name: {{ include "common.names.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "netbox.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}
+{{- end }}

--- a/charts/netbox/templates/secret.yaml
+++ b/charts/netbox/templates/secret.yaml
@@ -52,12 +52,12 @@ type: Opaque
 data:
   db_password: {{ .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}
-{{- if not (or .Values.redis.enabled (and .Values.tasksRedis.existingSecretName .Values.cachingRedis.existingSecretName)) }}
+{{- if not (or .Values.valkey.enabled (and .Values.tasksDatabase.existingSecretName .Values.cachingDatabase.existingSecretName)) }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.secrets.name" (dict "defaultNameSuffix" "redis" "context" $) }}
+  name: {{ include "common.secrets.name" (dict "defaultNameSuffix" "kv" "context" $) }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
@@ -65,10 +65,10 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- if not .Values.tasksRedis.existingSecretName }}
-  redis_tasks_password: {{ .Values.tasksRedis.password | b64enc | quote }}
+  {{- if not .Values.tasksDatabase.existingSecretName }}
+  tasks_password: {{ .Values.tasksDatabase.password | b64enc | quote }}
   {{- end }}
-  {{- if not .Values.cachingRedis.existingSecretName }}
-  redis_cache_password: {{ .Values.cachingRedis.password | b64enc | quote }}
+  {{- if not .Values.cachingDatabase.existingSecretName }}
+  cache_password: {{ .Values.cachingDatabase.password | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/netbox/templates/worker/deployment.yaml
+++ b/charts/netbox/templates/worker/deployment.yaml
@@ -181,15 +181,15 @@ spec:
               - key: {{ include "netbox.postgresql.secretKey" . | quote }}
                 path: db_password
           - secret:
-              name: {{ include "netbox.tasksRedis.secret" . | quote }}
+              name: {{ include "netbox.tasksDatabase.secret" . | quote }}
               items:
-              - key: {{ include "netbox.tasksRedis.secretKey" . | quote }}
-                path: redis_tasks_password
+              - key: {{ include "netbox.tasksDatabase.secretKey" . | quote }}
+                path: tasks_password
           - secret:
-              name: {{ include "netbox.cachingRedis.secret" . | quote }}
+              name: {{ include "netbox.cachingDatabase.secret" . | quote }}
               items:
-              - key: {{ include "netbox.cachingRedis.secretKey" . | quote }}
-                path: redis_cache_password
+              - key: {{ include "netbox.cachingDatabase.secretKey" . | quote }}
+                path: cache_password
       {{- include "netbox.extraConfig.volumes" . | nindent 6 }}
       - name: netbox-tmp
         emptyDir:

--- a/charts/netbox/templates/worker/deployment.yaml
+++ b/charts/netbox/templates/worker/deployment.yaml
@@ -39,8 +39,33 @@ spec:
       {{- if .Values.worker.podSecurityContext.enabled }}
       securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.worker.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.worker.initContainers }}
-      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.worker.initContainers "context" $) | trim | nindent 8 }}
+      {{- if or .Values.worker.initContainers .Values.worker.waitForBackend.enabled }}
+      initContainers:
+        {{- if .Values.worker.waitForBackend.enabled }}
+        - name: wait-for-backend
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.worker.waitForBackend.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.worker.waitForBackend.image.pullPolicy | quote }}
+          {{- if .Values.worker.waitForBackend.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.worker.waitForBackend.command "context" $) | nindent 10 }}
+          {{- end }}
+          {{- if .Values.worker.waitForBackend.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.worker.waitForBackend.args "context" $) | nindent 10 }}
+          {{- end }}
+          {{- if .Values.worker.waitForBackend.containerSecurityContext.enabled }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.worker.waitForBackend.containerSecurityContext "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.worker.waitForBackend.resources }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.worker.waitForBackend.resources "context" $) | nindent 12 }}
+          {{- else if ne .Values.worker.waitForBackend.resourcesPreset "none" }}
+          resources: {{- include "common.resources.preset" (dict "type" .Values.worker.waitForBackend.resourcesPreset) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: DEPLOYMENT_NAME
+              value: {{ include "common.names.fullname" . }}
+        {{- end }}
+        {{- if .Values.worker.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.worker.initContainers "context" $) | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}-worker

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -917,6 +917,17 @@
     "rackElevationDefaultUnitWidth": {
       "type": "integer"
     },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "rules": {
+          "type": "array"
+        }
+      }
+    },
     "readinessProbe": {
       "$ref": "#/$defs/probe"
     },
@@ -1622,6 +1633,99 @@
           "properties": {
             "type": {
               "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "waitForBackend": {
+          "properties": {
+            "args": {
+              "type": "array"
+            },
+            "command": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "podSecurityContext": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "fsGroup": {
+                  "type": "integer"
+                },
+                "fsGroupChangePolicy": {
+                  "type": "string"
+                },
+                "supplementalGroups": {
+                  "type": "array"
+                },
+                "sysctls": {
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "resources": {
+              "properties": {},
+              "type": "object"
+            },
+            "resourcesPreset": {
+              "type": "string"
+            },
+            "securityContext": {
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "type": "boolean"
+                },
+                "capabilities": {
+                  "properties": {
+                    "drop": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "privileged": {
+                  "type": "boolean"
+                },
+                "readOnlyRootFilesystem": {
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "seccompProfile": {
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
             }
           },
           "type": "object"

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -197,7 +197,7 @@
     "basePath": {
       "type": "string"
     },
-    "cachingRedis": {
+    "cachingDatabase": {
       "properties": {
         "caCertPath": {
           "type": "string"
@@ -931,9 +931,9 @@
     "readinessProbe": {
       "$ref": "#/$defs/probe"
     },
-    "redis": {
-      "title": "Redis chart configuration",
-      "description": "https://artifacthub.io/packages/helm/bitnami/redis",
+    "valkey": {
+      "title": "Valkey chart configuration",
+      "description": "https://artifacthub.io/packages/helm/bitnami/valkey",
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -1327,7 +1327,7 @@
       },
       "type": "object"
     },
-    "tasksRedis": {
+    "tasksDatabase": {
       "properties": {
         "caCertPath": {
           "type": "string"

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -379,6 +379,9 @@
         "disableServerSideCursors": {
           "type": "boolean"
         },
+        "engine": {
+          "type": "string"
+        },
         "existingSecretKey": {
           "type": "string"
         },
@@ -401,6 +404,9 @@
           "type": "string"
         }
       },
+      "type": "object"
+    },
+    "additionalDatabases": {
       "type": "object"
     },
     "extraConfig": {

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -1303,10 +1303,7 @@
     "startupProbe": {
       "$ref": "#/$defs/probe"
     },
-    "storageBackend": {
-      "type": "string"
-    },
-    "storageConfig": {
+    "storages": {
       "properties": {},
       "type": "object"
     },

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -632,6 +632,25 @@ serviceAccount:
   annotations: {}
   name: ""
   automountServiceAccountToken: false
+## Role Based Access
+## ref: https://kubernetes.io/docs/admin/authorization/rbac/
+##
+rbac:
+  ## @param rbac.create Specifies whether RBAC resources should be created
+  ##
+  create: true
+  ## @param rbac.rules Custom RBAC rules to set
+  ## e.g:
+  ## rules:
+  ##   - apiGroups:
+  ##       - ""
+  ##     resources:
+  ##       - pods
+  ##     verbs:
+  ##       - get
+  ##       - list
+  ##
+  rules: []
 ## @param hostAliases [array] Add deployment host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
@@ -834,7 +853,7 @@ startupProbe:
   initialDelaySeconds: 5
   periodSeconds: 10
   timeoutSeconds: 1
-  failureThreshold: 10
+  failureThreshold: 100
   successThreshold: 1
 ## @param customLivenessProbe Override default liveness probe for containers
 ##
@@ -1511,7 +1530,7 @@ worker:
   readOnlyPersistence: false
   ## @param worker.automountServiceAccountToken Mount Service Account token in pod
   ##
-  automountServiceAccountToken: false
+  automountServiceAccountToken: true
   ## @param worker.affinity Affinity for worker pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
@@ -1634,3 +1653,96 @@ worker:
   ##    command: ['sh', '-c', 'echo "init"']
   ##
   initContainers: []
+  ## Init containers parameters:
+  ## wait-for-backend: Wait for NetBox backend before running workers
+  ##
+  waitForBackend:
+    ## @param waitForBackend.enabled Wait for NetBox backend before running workers
+    ##
+    enabled: true
+    ## @param waitForBackend.image.registry [default: REGISTRY_NAME] Init container wait-for-backend image registry
+    ## @param waitForBackend.image.repository [default: REPOSITORY_NAME/kubectl] Init container wait-for-backend image name
+    ## @param waitForBackend.image.tag Init container wait-for-backend image tag
+    ## @param waitForBackend.image.digest Init container wait-for-backend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+    ## @param waitForBackend.image.pullPolicy Init container wait-for-backend image pull policy
+    ## @param waitForBackend.image.pullSecrets Specify docker-registry secret names as an array
+    ##
+    image:
+      registry: docker.io
+      repository: bitnami/kubectl
+      tag: 1.32.2-debian-12-r3
+      digest: ""
+      ## Specify a imagePullPolicy
+      ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## Example:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+    ## @param waitForBackend.command The command to execute in the wait-for-backend container
+    ##
+    command:
+      - /bin/bash
+      - -ec
+    ## @param waitForBackend.args Override wait-for-backend container args
+    ##
+    args:
+      - |
+        deployment=${DEPLOYMENT_NAME:?deployment name is missing}
+        return_code=0
+
+        echo "Waiting for deployment \"${deployment}\" to be successfully rolled out..."
+        kubectl rollout status deployment "$deployment" 2>&1 || return_code=$?
+        echo "Rollout exit code: '${return_code}'"
+        exit $return_code
+    ## waitForBackend containers' Security Context (init container).
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+    ## @param waitForBackend.containerSecurityContext.enabled Enabled containers' Security Context
+    ## @param waitForBackend.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
+    ## @param waitForBackend.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+    ## @param waitForBackend.containerSecurityContext.runAsGroup Set containers' Security Context runAsGroup
+    ## @param waitForBackend.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+    ## @param waitForBackend.containerSecurityContext.privileged Set container's Security Context privileged
+    ## @param waitForBackend.containerSecurityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+    ## @param waitForBackend.containerSecurityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+    ## @param waitForBackend.containerSecurityContext.capabilities.drop List of capabilities to be dropped
+    ## @param waitForBackend.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
+    ##
+    containerSecurityContext:
+      enabled: true
+      seLinuxOptions: {}
+      runAsUser: 1001
+      runAsGroup: 1001
+      runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"
+    ## Init container resource requests and limits.
+    ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    ## We usually recommend not to specify default resources and to leave this as a conscious
+    ## choice for the user. This also increases chances charts run on environments with little
+    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## @param waitForBackend.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if waitForBackend.resources is set (waitForBackend.resources is recommended for production).
+    ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+    ##
+    resourcesPreset: "nano"
+    ## @param waitForBackend.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+    ## Example:
+    ## resources:
+    ##   requests:
+    ##     cpu: 2
+    ##     memory: 512Mi
+    ##   limits:
+    ##     cpu: 3
+    ##     memory: 1024Mi
+    ##
+    resources: {}

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -1058,6 +1058,7 @@ externalDatabase:
   existingSecretKey: postgresql-password
 
   # The following settings also apply when using the bundled PostgreSQL chart:
+  engine: django.db.backends.postgresql
   connMaxAge: 300
   disableServerSideCursors: false
   ## @param externalDatabase.options Additional PostgreSQL client parameters
@@ -1066,6 +1067,29 @@ externalDatabase:
   options:
     sslmode: "prefer"
     target_session_attrs: "read-write"
+
+## Additional databases configuration
+## @param additionalDatabases.*.host Host of the existing database
+## @param additionalDatabases.*.port Port of the existing database
+## @param additionalDatabases.*.username Existing username in the external db
+## @param additionalDatabases.*.password Password for the above username
+## @param additionalDatabases.*.database Name of the existing database
+## e.g:
+## additionalDatabases:
+##   external2:
+##     host: localhost
+##     port: 5432
+##     database: netbox
+##     username: netbox
+##     password: ""
+##     engine: django.db.backends.postgresql
+##     connMaxAge: 300
+##     disableServerSideCursors: false
+##     options:
+##       sslmode: "prefer"
+##       target_session_attrs: "read-write"
+##
+additionalDatabases: {}
 
 ## Valkey chart configuration
 ## https://github.com/bitnami/charts/blob/main/bitnami/valkey/values.yaml

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -310,21 +310,24 @@ mapsUrl: "https://maps.google.com/?q="
 # all objects by specifying "?limit=0".
 maxPageSize: 1000
 
-# By default uploaded media is stored in an attached volume. Using
-# Django-storages is also supported. Provide the class path of the storage
-# driver in storageBackend and any configuration options in storageConfig.
-# storageBackend: storages.backends.s3boto3.S3Boto3Storage
-storageBackend: ""
-# Configuration for the storage backend can be provided using storageConfig.
-# Note these values are not stored securely. If the configuration must be
-# setup in a more secure way, a propor Secret can be used with extraEnvVarsSecret.
-# storageConfig:
-#   AWS_ACCESS_KEY_ID: 'Key ID'
-#   AWS_SECRET_ACCESS_KEY: 'Secret'
-#   AWS_STORAGE_BUCKET_NAME: 'netbox'
-#   AWS_S3_ENDPOINT_URL: 'endpoint URL of S3 provider'
-#   AWS_S3_REGION_NAME: 'eu-west-1'
-storageConfig: {}
+## The backend storage engine for handling uploaded files such as image
+## attachments and custom scripts. NetBox integrates with the
+## django-storages and django-storage-swift libraries, which provide backends
+## for several popular file storage services. If not configured, local
+## filesystem storage will be used.
+## Note these values are not stored securely. If the configuration must be
+## setup in a more secure way, a propor Secret can be used with extraEnvVarsSecret.
+## ref: https://netboxlabs.com/docs/netbox/en/stable/configuration/system/#storages
+## e.g:
+## storages:
+##   default:
+##     BACKEND: "django.core.files.storage.FileSystemStorage"
+##   scripts:
+##     BACKEND: "storages.backends.s3.S3Storage"
+##     OPTIONS:
+##       access_key: "access key"
+##       secret_key: "secret key"
+storages: {}
 
 # Determine how many objects to display per page within a list. (Default: 50)
 paginateCount: 50

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -625,10 +625,10 @@ updateStrategy:
   type: RollingUpdate
 ## Pods Service Account
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-## @param master.serviceAccount.create Specifies whether a ServiceAccount should be created
-## @param master.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
-## @param master.serviceAccount.automountServiceAccountToken Automount service account token for the server service account
-## @param master.serviceAccount.annotations Annotations for service account. Evaluated as a template. Only used if `create` is `true`.
+## @param serviceAccount.create Specifies whether a ServiceAccount should be created
+## @param serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
+## @param serviceAccount.automountServiceAccountToken Automount service account token for the server service account
+## @param serviceAccount.annotations Annotations for service account. Evaluated as a template. Only used if `create` is `true`.
 ##
 serviceAccount:
   create: true
@@ -661,17 +661,17 @@ hostAliases: []
 ## @param extraVolumes Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`
 ## e.g:
 ## extraVolumes:
-##   - name: redis-ca
+##   - name: kv-ca
 ##     secret:
-##       secretName: redis-ca
+##       secretName: kv-ca
 ##
 extraVolumes: []
 ## @param extraVolumeMounts Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.
 ## e.g:
 ## extraVolumeMounts:
-##   - name: redis-ca
-##     mountPath: /tmp/redis-ca
-##     subPath: redis_ca
+##   - name: kv-ca
+##     mountPath: /tmp/kv-ca
+##     subPath: kv_ca
 ##     readOnly: true
 ##
 extraVolumeMounts: []
@@ -1067,52 +1067,52 @@ externalDatabase:
     sslmode: "prefer"
     target_session_attrs: "read-write"
 
-## Redis chart configuration
-## https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml
-## @param redis.enabled Deploy Redis using bundled Bitnami Redis chart
+## Valkey chart configuration
+## https://github.com/bitnami/charts/blob/main/bitnami/valkey/values.yaml
+## @param valkey.enabled Whether to deploy a Valkey server to satisfy the applications database requirements
 ##
-redis:
+valkey:
   enabled: true
 
-tasksRedis:
+tasksDatabase:
   database: 0
   ssl: false
   insecureSkipTlsVerify: false
   # When defining caCertPath, make sure you mount the secret containing the CA certificate on all the necessary containers
   caCertPath: ""
 
-  # Used only when redis.enabled is false. host and port are not used if
+  # Used only when valkey.enabled is false. host and port are not used if
   # sentinels are given.
-  host: netbox-redis
+  host: netbox-kv
   port: 6379
   sentinels: []
   #  - mysentinel:26379
-  sentinelService: netbox-redis
+  sentinelService: netbox-kv
   sentinelTimeout: 300
   username: ""
   password: ""
   existingSecretName: ""
-  existingSecretKey: redis-password
+  existingSecretKey: tasks-password
 
-cachingRedis:
+cachingDatabase:
   database: 1
   ssl: false
   insecureSkipTlsVerify: false
   # When defining caCertPath, make sure you mount the secret containing the CA certificate on all the necessary containers
   caCertPath: ""
 
-  # Used only when redis.enabled is false. host and port are not used if
+  # Used only when valkey.enabled is false. host and port are not used if
   # sentinels are given.
-  host: netbox-redis
+  host: netbox-kv
   port: 6379
   sentinels: []
   #  - mysentinel:26379
-  sentinelService: netbox-redis
+  sentinelService: netbox-kv
   sentinelTimeout: 300
   username: ""
   password: ""
   existingSecretName: ""
-  existingSecretKey: redis-password
+  existingSecretKey: cache-password
 
 ## @section Autoscaling parameters
 
@@ -1384,17 +1384,17 @@ housekeeping:
   ## @param housekeeping.extraVolumes Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`
   ## e.g:
   ## extraVolumes:
-  ##   - name: redis-ca
+  ##   - name: kv-ca
   ##     secret:
-  ##       secretName: redis-ca
+  ##       secretName: kv-ca
   ##
   extraVolumes: []
   ## @param housekeeping.extraVolumeMounts Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.
   ## e.g:
   ## extraVolumeMounts:
-  ##   - name: redis-ca
-  ##     mountPath: /tmp/redis-ca
-  ##     subPath: redis_ca
+  ##   - name: kv-ca
+  ##     mountPath: /tmp/kv-ca
+  ##     subPath: kv_ca
   ##     readOnly: true
   ##
   extraVolumeMounts: []
@@ -1621,17 +1621,17 @@ worker:
   ## @param worker.extraVolumes Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`
   ## e.g:
   ## extraVolumes:
-  ##   - name: redis-ca
+  ##   - name: kv-ca
   ##     secret:
-  ##       secretName: redis-ca
+  ##       secretName: kv-ca
   ##
   extraVolumes: []
   ## @param worker.extraVolumeMounts Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.
   ## e.g:
   ## extraVolumeMounts:
-  ##   - name: redis-ca
-  ##     mountPath: /tmp/redis-ca
-  ##     subPath: redis_ca
+  ##   - name: kv-ca
+  ##     mountPath: /tmp/kv-ca
+  ##     subPath: kv_ca
   ##     readOnly: true
   ##
   extraVolumeMounts: []


### PR DESCRIPTION
Milestone: https://github.com/netbox-community/netbox-chart/milestone/5

- [x] https://github.com/netbox-community/netbox-chart/pull/332
- [x] https://github.com/netbox-community/netbox-chart/pull/601
- [x] https://github.com/netbox-community/netbox-chart/pull/647
- [x] https://github.com/netbox-community/netbox-chart/pull/656
- [x] https://github.com/netbox-community/netbox-chart/pull/659
- [x] https://github.com/netbox-community/netbox-chart/pull/660

---

```md
# Upgrade Notes

- NetBox has been updated to version 4.3 which introduces some configuration changes.
  - `storageBackend` and `storageConfig` have been dropped in favor of the new `storages` (https://github.com/netbox-community/netbox-chart/pull/656).
  - `externalDatabase` now defines the default database (non-breaking), while additional databases can be set using `additionalDatabases` (https://github.com/netbox-community/netbox-chart/pull/659)
- The Bitnami [Redis](https://github.com/bitnami/charts/tree/main/bitnami/redis) sub-chart has been replaced by the Bitnami [Valkey](https://github.com/bitnami/charts/tree/main/bitnami/valkey) sub-chart (https://github.com/netbox-community/netbox-chart/pull/332).
  - If `redis.enabled` was true, ensure to replace `redis.*` by `valkey.*` or provide your own Redis instance.
  - Values `tasksRedis.*` has been renamed to `tasksDatabase.*`
  - Values `cachingRedis.*` has been renamed to `cachingDatabase.*`
  - Related default password secrets keys have been made generic, from `redis-password` to `tasks-password` and `cache-password`.
- A new initial container has been added to the worker spec to prevent failures or restart loops during deployments, and is enabled by default (https://github.com/netbox-community/netbox-chart/pull/601).
  - See `worker.waitForBackend`.
  - RBAC with a proper role is mandatory for this task, see `rbac`.
```