### PR TITLE
Updates schema to support string extras

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 6.0.8
+version: 6.0.9
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.3.0"
 type: application

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -416,7 +416,7 @@
       "type": "array"
     },
     "extraEnvs": {
-      "type": "array"
+      "type": [ "array", "string" ]
     },
     "extraEnvVarsCM": {
       "type": "string",
@@ -429,10 +429,10 @@
       "default": ""
     },
     "extraVolumeMounts": {
-      "type": "array"
+      "type": [ "array", "string" ]
     },
     "extraVolumes": {
-      "type": "array"
+      "type": [ "array", "string" ]
     },
     "fieldChoices": {
       "properties": {},

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -416,7 +416,7 @@
       "type": "array"
     },
     "extraEnvs": {
-      "type": [ "array", "string" ]
+      "type": ["array", "string"]
     },
     "extraEnvVarsCM": {
       "type": "string",
@@ -429,10 +429,10 @@
       "default": ""
     },
     "extraVolumeMounts": {
-      "type": [ "array", "string" ]
+      "type": ["array", "string"]
     },
     "extraVolumes": {
-      "type": [ "array", "string" ]
+      "type": ["array", "string"]
     },
     "fieldChoices": {
       "properties": {},


### PR DESCRIPTION
TL;DR
-----

Allows templated strings for `extras` in the `values.yaml` file

Details
-------

Lets users advantage of the underlying `common.tplvalus.render`
function used to render `extraEnvs`, `extraVolumes`, and
`extraVolumeMounts` by opening up the values schema so that either a
string or an array can be passed in for those values.
