### PR TITLE
Add timezone parameter for housekeeping cronjob

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 6.0.17
+version: 6.0.18
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.3.1"
 type: application

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -15,6 +15,9 @@ spec:
   schedule: {{ .Values.housekeeping.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.housekeeping.successfulJobsHistoryLimit }}
   suspend: {{ .Values.housekeeping.suspend }}
+  {{- if ge (int .Capabilities.KubeVersion.Minor) 27 }}
+  timeZone: {{ .Values.housekeeping.timezone }}
+  {{- end }}
   jobTemplate:
     metadata:
       labels:

--- a/charts/netbox/templates/cronjob.yaml
+++ b/charts/netbox/templates/cronjob.yaml
@@ -15,7 +15,7 @@ spec:
   schedule: {{ .Values.housekeeping.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.housekeeping.successfulJobsHistoryLimit }}
   suspend: {{ .Values.housekeeping.suspend }}
-  {{- if ge (int .Capabilities.KubeVersion.Minor) 27 }}
+  {{- if .Values.housekeeping.timezone }}
   timeZone: {{ .Values.housekeeping.timezone }}
   {{- end }}
   jobTemplate:

--- a/charts/netbox/values.schema.json
+++ b/charts/netbox/values.schema.json
@@ -618,6 +618,9 @@
         "suspend": {
           "type": "boolean"
         },
+        "timezone": {
+          "type": "string"
+        },
         "tolerations": {
           "type": "array"
         }

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -1307,6 +1307,11 @@ housekeeping:
   ## See https://en.wikipedia.org/wiki/Cron
   ##
   schedule: "0 0 * * *"
+  ## @param housekeeping.timezone Set timeZone for cronjob
+  ## Will work since kubernetes 1.27
+  ## See https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+  ##
+  timezone: "Etc/UTC"
   ## @param housekeeping.historyLimit Number of successful finished jobs to retain
   ##
   successfulJobsHistoryLimit: 5

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -1307,9 +1307,8 @@ housekeeping:
   ## See https://en.wikipedia.org/wiki/Cron
   ##
   schedule: "0 0 * * *"
-  ## @param housekeeping.timezone Set timeZone for cronjob
-  ## Will work since kubernetes 1.27
-  ## See https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+  ## @param housekeeping.timezone Set time zone for cron job
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
   ##
   timezone: ""
   ## @param housekeeping.historyLimit Number of successful finished jobs to retain

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -1311,7 +1311,7 @@ housekeeping:
   ## Will work since kubernetes 1.27
   ## See https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
   ##
-  timezone: "Etc/UTC"
+  timezone: ""
   ## @param housekeeping.historyLimit Number of successful finished jobs to retain
   ##
   successfulJobsHistoryLimit: 5


### PR DESCRIPTION
Add timezone parameter for housekeeping cronjob
By default cronjob run in UTC timezone and it's little be confusing sometimes and can be customized
According [this](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones) reference manual we can set timezone param since kubernetes 1.27 version