### PR TITLE
Fix secret key name

### DIFF
--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -246,7 +246,7 @@ spec:
               name: {{ include "netbox.postgresql.secret" . | quote }}
               items:
               - key: {{ include "netbox.postgresql.secretKey" . | quote }}
-                path: db_password
+                path: password
           - secret:
               name: {{ include "netbox.tasksDatabase.secret" . | quote }}
               items:


### PR DESCRIPTION
This pull request includes a minor update to the `charts/netbox/templates/deployment.yaml` file. The change modifies the key name for a secret path to improve consistency.

* [`charts/netbox/templates/deployment.yaml`](diffhunk://#diff-f8cd26b6673dc5780e82d9da5451a5e5293f2aeb84219f5e996d7e46b38874e0L249-R249): Updated the secret path key from `db_password` to `password` for better alignment with naming conventions.