### PR TITLE
Fix using external sentinels

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 6.1.10
+version: 6.1.11
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.3.6"
 type: application

--- a/charts/netbox/templates/_helpers.tpl
+++ b/charts/netbox/templates/_helpers.tpl
@@ -127,7 +127,7 @@ Tasks Sentinel: use .Values.tasksDatabase.sentinels if defined. When using embed
 */}}
 {{- define "netbox.tasksDatabase.sentinels" -}}
   {{- if .Values.tasksDatabase.sentinels }}
-    {{- .Values.tasksDatabase.sentinels }}
+    {{- toJson .Values.tasksDatabase.sentinels }}
   {{- else if and .Values.valkey.enabled .Values.valkey.sentinel.enabled }}
     {{- include "netbox.valkey.managedSentinels" . }}
   {{- end }}
@@ -138,7 +138,7 @@ Caching Sentinel: use .Values.cachingDatabase.sentinels if defined. When using e
 */}}
 {{- define "netbox.cachingDatabase.sentinels" -}}
   {{- if .Values.cachingDatabase.sentinels }}
-    {{- .Values.cachingDatabase.sentinels }}
+    {{- toJson .Values.cachingDatabase.sentinels }}
   {{- else if and .Values.valkey.enabled .Values.valkey.sentinel.enabled }}
     {{- include "netbox.valkey.managedSentinels" . }}
   {{- end }}


### PR DESCRIPTION
When using external sentinels, the generated YAML looks something like this:

```
REDIS:
  tasks:
    SENTINELS: [netbox-redis-ha-announce-0:26379 netbox-redis-ha-announce-1:26379 netbox-redis-ha-announce-2:26379]
```

This PR fixes it so it looks like this:

```
REDIS:
  tasks:
    SENTINELS: ["netbox-redis-ha-announce-0:26379","netbox-redis-ha-announce-1:26379","netbox-redis-ha-announce-2:26379"]
```

And thus, external sentinels can be used again.