### PR TITLE
Replace worker.waitForBackend container image

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netbox
-version: 6.1.17
+version: 6.1.18
 # renovate: image=ghcr.io/netbox-community/netbox
 appVersion: "v4.4.0"
 type: application

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -1706,8 +1706,8 @@ worker:
     ##
     image:
       registry: docker.io
-      repository: bitnami/kubectl
-      tag: 1.33.4-debian-12-r0
+      repository: rancher/kubectl
+      tag: v1.34.1
       digest: ""
       ## Specify a imagePullPolicy
       ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
@@ -1722,20 +1722,10 @@ worker:
       pullSecrets: []
     ## @param waitForBackend.command The command to execute in the wait-for-backend container
     ##
-    command:
-      - /bin/bash
-      - -ec
+    command: [/bin/kubectl]
     ## @param waitForBackend.args Override wait-for-backend container args
     ##
-    args:
-      - |
-        deployment=${DEPLOYMENT_NAME:?deployment name is missing}
-        return_code=0
-
-        echo "Waiting for deployment \"${deployment}\" to be successfully rolled out..."
-        kubectl rollout status deployment "$deployment" 2>&1 || return_code=$?
-        echo "Rollout exit code: '${return_code}'"
-        exit $return_code
+    args: [rollout, status, deployment, "$(DEPLOYMENT_NAME)"]
     ## waitForBackend containers' Security Context (init container).
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
     ## @param waitForBackend.containerSecurityContext.enabled Enabled containers' Security Context


### PR DESCRIPTION
Stop using bitnami/kubectl and replace it with rancher/kubectl. The latter doesn't include a shell so just call kubectl directly without wrapping it in an unnecessary shell script.