### PR TITLE
Fix Granian metrics scraping

### DIFF
--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -84,6 +84,8 @@ spec:
         {{- if and .Values.metrics.enabled .Values.metrics.granian.enabled }}
         - name: GRANIAN_METRICS_ENABLED
           value: {{ .Values.metrics.granian.enabled | quote }}
+        - name: GRANIAN_METRICS_ADDRESS
+          value: "0.0.0.0"
         {{- if and .Values.metrics.granian.serviceMonitor.enabled .Values.metrics.granian.serviceMonitor.interval }}
         - name: GRANIAN_METRICS_SCRAPE_INTERVAL
           value: {{ .Values.metrics.granian.serviceMonitor.interval | quote }}


### PR DESCRIPTION
The Granian metrics server only listens on 127.0.0.1 by default, meaning it cannot be scraped from monitoring pods.

This PR changes the listening address to 0.0.0.0 via an environment variable when Granian metrics are enabled.